### PR TITLE
PersistenceConfiguration with JNDI

### DIFF
--- a/errai-persistence/src/main/java/org/jboss/errai/persistence/server/HibernateAdapter.java
+++ b/errai-persistence/src/main/java/org/jboss/errai/persistence/server/HibernateAdapter.java
@@ -15,36 +15,92 @@
  */
 package org.jboss.errai.persistence.server;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.persistence.EntityManagerFactory;
+
+import net.sf.gilead.core.IPersistenceUtil;
 import net.sf.gilead.core.PersistentBeanManager;
 import net.sf.gilead.core.hibernate.HibernateUtil;
+import net.sf.gilead.core.hibernate.jboss.HibernateJBossUtil;
+import net.sf.gilead.core.hibernate.jpa.HibernateJpaUtil;
 import net.sf.gilead.core.store.stateful.InMemoryProxyStore;
 import org.hibernate.SessionFactory;
 import org.jboss.errai.bus.client.framework.ModelAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author: Heiko Braun <hbraun@redhat.com>
  * @date: Jun 16, 2010
  */
 public class HibernateAdapter implements ModelAdapter {
-    private PersistentBeanManager beanManager;
+	
+	private Logger logger = LoggerFactory.getLogger(this.getClass());
+	
+	private PersistentBeanManager beanManager;
+	private String jndiName;
+	private boolean useJbossUtil;
+	private boolean usingJpa;
 
-    public HibernateAdapter(final SessionFactory sessionFactory) {
-        // configure gilead
-        final HibernateUtil persistenceUtil = new HibernateUtil();
-        persistenceUtil.setSessionFactory(sessionFactory);
-
-        // TODO: This should actually be a session bound proxy store instead of a global one
-        final InMemoryProxyStore proxyStore = new InMemoryProxyStore();
-        proxyStore.setPersistenceUtil(persistenceUtil);
-
-        beanManager = new PersistentBeanManager();
-        beanManager.setPersistenceUtil(persistenceUtil);
-        beanManager.setProxyStore(proxyStore);
+	/**
+	 * Create adapter.
+	 * 
+	 * @param jndiName - factory jndi name
+	 * @param useJbossUtil - use jboss specific gilead persistence util
+	 * @param usingJpa - if true {@link PersistentBeanManager} will be configured with {@link EntityManagerFactory} 
+	 * 			otherwise with {@link SessionFactory}
+	 */
+    public HibernateAdapter(String jndiName, boolean useJbossUtil, boolean usingJpa) {
+		this.jndiName = jndiName;
+		this.useJbossUtil = useJbossUtil;
+		this.usingJpa = usingJpa;		
     }
 
+    /**
+     *  Lazy initialization of the {@link PersistentBeanManager}. 
+     *  At this time factory should be bound in the jndi.
+     */
+	protected void initPersistentBeanManager() {
+		logger.debug("Initializing PersistentBeanManager");
+		Object factory;
+		try {
+			factory = new InitialContext().lookup(jndiName);
+		} catch (NamingException e) {
+			logger.error("Cold not lookup : "+jndiName);
+			e.printStackTrace();
+			return;
+		}
+		IPersistenceUtil util;
+		if (useJbossUtil) {
+			if (usingJpa) {
+				util = new HibernateJBossUtil((EntityManagerFactory)factory);
+			} else {
+				util = new HibernateJBossUtil((SessionFactory) factory);
+			}
+		} else {
+			if (usingJpa) {
+				util = new HibernateJpaUtil((EntityManagerFactory)factory);
+			} else {
+				util = new HibernateUtil((SessionFactory) factory);
+			}			
+		}
+		
+        // TODO: This should actually be a session bound proxy store instead of a global one
+		InMemoryProxyStore proxyStore = new InMemoryProxyStore();
+		proxyStore.setPersistenceUtil(util);
+		beanManager = PersistentBeanManager.getInstance();
+		beanManager.setPersistenceUtil(util);
+		beanManager.setProxyStore(proxyStore);
+	}
+    
     public Object clone(Object entity) {
         if (entity == null)
             return null;
+        
+		if (beanManager == null) {
+			initPersistentBeanManager();
+		}
 
         return beanManager.clone(entity);
     }
@@ -52,6 +108,10 @@ public class HibernateAdapter implements ModelAdapter {
     public Object merge(Object dto) {
         if (dto == null)
             return null;
+        
+		if (beanManager == null) {
+			initPersistentBeanManager();
+		}
 
         return beanManager.merge(dto);
     }

--- a/errai-persistence/src/main/java/org/jboss/errai/persistence/server/PersistenceConfiguration.java
+++ b/errai-persistence/src/main/java/org/jboss/errai/persistence/server/PersistenceConfiguration.java
@@ -17,32 +17,24 @@
 package org.jboss.errai.persistence.server;
 
 import com.google.inject.Inject;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.cfg.AnnotationConfiguration;
 import org.jboss.errai.bus.client.api.ResourceProvider;
 import org.jboss.errai.bus.client.framework.ModelAdapter;
-import org.jboss.errai.bus.server.ErraiBootstrapFailure;
 import org.jboss.errai.bus.server.annotations.ExtensionComponent;
 import org.jboss.errai.bus.server.api.ErraiConfig;
 import org.jboss.errai.bus.server.api.ErraiConfigExtension;
 import org.jboss.errai.bus.server.service.ErraiServiceConfigurator;
-import org.jboss.errai.bus.server.service.metadata.MetaDataScanner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.persistence.Entity;
-import java.util.Set;
-
-
 /**
- * Configures the hibernate SessionFactory and make it available
- * as an injection point in guice ( see {@link ResourceProvider} ).
- *
+ * 
+ * Configures {@link HibernateAdapter} and make it available
+ * as an injection point in guice ( see {@link ResourceProvider} )
  *
  */
 @ExtensionComponent
 public class PersistenceConfiguration implements ErraiConfigExtension {
+	
   private ErraiServiceConfigurator configurator;
   private Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -54,74 +46,27 @@ public class PersistenceConfiguration implements ErraiConfigExtension {
   }
 
   public void configure(ErraiConfig config) {
-    final AnnotationConfiguration cfg = new AnnotationConfiguration();
-    if (!configurator.hasProperty("errai.prototyping.persistence.connection.driver_class")) {
-      return;
-    }
+	logger.info("Configuring persistence extension.");
+	if (!configurator.hasProperty("errai.persistence.factory.jndi.name")) {
+		logger.info("Stopped configuring persistence extension, can't find errai.factory.jndi.name.");
+		return;
+	} 
+	String jndiName = configurator.getProperty("errai.persistence.factory.jndi.name");
+	boolean useJbossUtil = Boolean.valueOf(configurator.getProperty("errai.persistence.use_jboss_util"));
+	boolean usingJpa = Boolean.valueOf(configurator.getProperty("errai.persistence.using_jpa"));
+	logger.info("Factory JNDI name : "+jndiName);
+	logger.info("Use jboss specific utility :  "+useJbossUtil);
+	logger.info("Using JPA  : "+usingJpa);
 
-    cfg.setProperty("hibernate.connection.driver_class", configurator.getProperty("errai.prototyping.persistence.connection.driver_class"));
-    cfg.setProperty("hibernate.connection.url", configurator.getProperty("errai.prototyping.persistence.connection.url"));
-    cfg.setProperty("hibernate.connection.username", configurator.getProperty("errai.prototyping.persistence.connection.username"));
-    cfg.setProperty("hibernate.connection.password", configurator.getProperty("errai.prototyping.persistence.connection.password"));
-    cfg.setProperty("hibernate.connection.pool_size", configurator.getProperty("errai.prototyping.persistence.connection.pool_size"));
+	final ModelAdapter modelAdapter = new HibernateAdapter(jndiName, useJbossUtil, usingJpa);
+	ResourceProvider<ModelAdapter> modelAdapterProvider = new ResourceProvider<ModelAdapter>() {
 
-    cfg.setProperty("hibernate.dialect", configurator.getProperty("errai.prototyping.persistence.dialect"));
-    cfg.setProperty("hibernate.current_session_context_class", "thread");
-    cfg.setProperty("hibernate.cache.use_second_level_cache", "false");
-    cfg.setProperty("hibernate.cache.provider_class", "org.hibernate.cache.NoCacheProvider");
-
-    cfg.setProperty("hibernate.show_sql", "true");
-    cfg.setProperty("hibernate.hbm2ddl.auto", "update");
-
-    logger.debug("begin scan for annotated classes.");
-    MetaDataScanner scanner = configurator.getMetaDataScanner();
-    Set<Class<?>> entities = scanner.getTypesAnnotatedWith(Entity.class);
-    for(Class<?> entity : entities)
-    {
-      cfg.addAnnotatedClass(entity);
-    }
-
-    try {
-      final SessionFactory sessionFactory = cfg.buildSessionFactory();
-      logger.info("finished building hibernate session factory ... ");
-
-      ResourceProvider<Session> sessionProvider = new ResourceProvider<Session>() {
-        public Session get() {
-          return sessionFactory.openSession();
-        }
-      };
-      ResourceProvider<SessionFactory> sessionFactoryProvider = new ResourceProvider() {
-        public Object get() {
-          return sessionFactory;
-        }
-      };
-
-      final ModelAdapter hibenateAdapter = new HibernateAdapter(sessionFactory);
-      ResourceProvider<ModelAdapter> modelAdapterProvider = new ResourceProvider<ModelAdapter>()
-      {
-        public ModelAdapter get()
-        {
-          return hibenateAdapter;
-        }
-      };
-      logger.info("adding binding for: " + hibenateAdapter.getClass());
-      config.addBinding(ModelAdapter.class, modelAdapterProvider);
-
-      logger.info("adding binding for: " + sessionProvider.getClass());
-      config.addBinding(Session.class, sessionProvider);
-
-      logger.info("adding binding for: " + sessionFactoryProvider.getClass());
-      config.addBinding(SessionFactory.class, sessionFactoryProvider);
-
-      logger.info("adding resource provider for: " + sessionProvider.getClass());
-      config.addResourceProvider("SessionProvider", sessionProvider);
-    }
-    catch (Throwable t) {
-      logger.info("session factory did not build: " + t.getClass());
-      t.printStackTrace();
-      throw new ErraiBootstrapFailure("could not load errai-persitence", t);
-    }
+		public ModelAdapter get() {
+			return modelAdapter;
+		}
+	};
+	
+	logger.info("Adding binding for: "+modelAdapter.getClass());
+	config.addBinding(ModelAdapter.class, modelAdapterProvider);
   }
-
-
 }


### PR DESCRIPTION
Here is the implementation of the Persistence Extension which uses hibernate SessionFactory or EntityManagerFactory obtained from JNDI. It's tested with EntityManagerFactory. Lookup to the jndi is done on the first call of merge or clone methods, because during errai bootstrap, jndi tree is not ready yet.
