### PR TITLE
Add PropertyChangeHandlers

### DIFF
--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/HasPropertyChangeHandlers.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/HasPropertyChangeHandlers.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012 JBoss, a division of Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.databinding.client;
+
+/**
+ * Implementors of HasPropertyChangeHandlers are a source of {@link PropertyChangeEvent} events.
+ * @author David Cracauer <dcracauer@gmail.com>
+ */
+public interface HasPropertyChangeHandlers {
+    
+    public void addPropertyChangeHandler(PropertyChangeHandler handler);
+    public void removePropertyChangeHandler(PropertyChangeHandler handler);
+    
+}

--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/PropertyChangeEvent.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/PropertyChangeEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012 JBoss, a division of Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.databinding.client;
+
+/**
+ * Dispatched when a bound property has changed.
+ * @author David Cracauer <dcracauer@gmail.com>
+ */
+public class PropertyChangeEvent {
+    
+    private String propertyName;
+    private Object oldValue;
+    private Object newValue;
+
+    public PropertyChangeEvent(String propertyName, Object oldValue, Object newValue) {
+        this.propertyName = propertyName;
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    public Object getNewValue() {
+        return newValue;
+    }
+
+    public Object getOldValue() {
+        return oldValue;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+    
+    
+}

--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/PropertyChangeHandler.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/PropertyChangeHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012 JBoss, a division of Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.databinding.client;
+
+/**
+ * A PropertyChangeEvent gets dispatched when any property of a bound bean is changed.
+ * @author David Cracauer <dcracauer@gmail.com>
+ */
+public interface PropertyChangeHandler {
+    
+    /**
+     * Called when {@link PropertyChangeEvent} is dispatched.
+     * @param event the {@link PropertyChangeEvent} that was dispatched.
+     * 
+     */
+    public void onPropertyChange(PropertyChangeEvent event);
+    
+}

--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/PropertyChangeHandlerSupport.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/PropertyChangeHandlerSupport.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012 JBoss, a division of Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.databinding.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang.ObjectUtils;
+
+/**
+ *
+ * @author David Cracauer <dcracauer@gmail.com>
+ */
+public class PropertyChangeHandlerSupport {
+    
+    private List<PropertyChangeHandler> handlers = new ArrayList<PropertyChangeHandler>();
+    
+    /**
+     * 
+     * Adds a {@link  PropertyChangeHandler} to the list of handlers.
+     * @param handler the {@link PropertyChangeHandler} to add.
+     */
+    public void addPropertyChangeHandler(PropertyChangeHandler handler){
+        handlers.add(handler);
+    }
+    /**
+     * 
+     * Removes a {@link  PropertyChangeHandler} from the list of handlers.
+     * @param handler the {@link PropertyChangeHandler} to remove.
+     */
+    public void removePropertyChangeHandler(PropertyChangeHandler handler){
+        handlers.remove(handler);
+    }
+    
+    /**
+     * Notify registered {@link PropertyChangeHandlers} of a {@link PropertyChangeEvent}.
+     * Will only dispatch events that represent a change; If oldValue and newValue are equal, the event will be ignored.
+     * @param event {@link the PropertyChangeEvent} to provide to handlers.
+     */
+    public void notifyHandlers(PropertyChangeEvent event){
+        if(!acceptEvent(event)){
+            return;
+        }
+    
+        for(PropertyChangeHandler handler : handlers){
+            handler.onPropertyChange(event);
+        }
+    }
+    
+    private boolean acceptEvent(PropertyChangeEvent event){
+        if(event == null){
+            return false;
+        }
+        
+        if(event.getOldValue() == null){
+            return event.getNewValue() != null;
+        }
+        
+        if(event.getNewValue()==null){
+            return event.getOldValue() != null;
+        }
+        
+        return !event.getOldValue().equals(event.getNewValue());
+        
+    }
+    
+}

--- a/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/MockHandler.java
+++ b/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/MockHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012 JBoss, a division of Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.databinding.client.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.errai.databinding.client.PropertyChangeEvent;
+import org.jboss.errai.databinding.client.PropertyChangeHandler;
+
+/**
+ *
+ * @author dcracauer
+ */
+public class MockHandler implements PropertyChangeHandler {
+    List<PropertyChangeEvent> events = new ArrayList<PropertyChangeEvent>();
+  
+
+ 
+
+    @Override
+    public void onPropertyChange(PropertyChangeEvent event) {
+        events.add(event);
+    }
+
+    public List<PropertyChangeEvent> getEvents() {
+        return events;
+    }
+    
+}

--- a/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/PropertyChangeHandlerSupportTest.java
+++ b/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/PropertyChangeHandlerSupportTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012 JBoss, a division of Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.databinding.client.test;
+
+import static org.junit.Assert.*;
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.errai.databinding.client.PropertyChangeEvent;
+import org.jboss.errai.databinding.client.PropertyChangeHandler;
+import org.jboss.errai.databinding.client.PropertyChangeHandlerSupport;
+import org.junit.*;
+
+/**
+ *
+ * @author dcracauer
+ */
+public class PropertyChangeHandlerSupportTest {
+    
+    private PropertyChangeHandlerSupport support;
+    
+    @Before
+    public void setUp() {
+        support = new PropertyChangeHandlerSupport();
+    }
+    
+    @Test
+    public void testAdd(){
+        
+        MockHandler mh1 = new MockHandler( );
+        support.addPropertyChangeHandler(mh1);
+        
+        PropertyChangeEvent event1 = new PropertyChangeEvent("foo", 1, 2);
+        
+        support.notifyHandlers(event1);
+        assertEquals(1, mh1.events.size());
+        assertEquals(event1, mh1.events.get(0));
+        
+        MockHandler mh2 = new MockHandler( );
+        
+        support.addPropertyChangeHandler(mh2);
+        
+        PropertyChangeEvent event2 = new PropertyChangeEvent("foo", 2, 3);
+        
+        support.notifyHandlers(event2);
+        assertEquals(2, mh1.events.size());
+        assertEquals(event2, mh1.events.get(1));
+        assertEquals(1, mh2.events.size());
+        assertEquals(event2, mh2.events.get(0));
+        
+    }
+    
+      
+    @Test
+    public void testRemove(){
+        MockHandler mh1 = new MockHandler( );
+        support.addPropertyChangeHandler(mh1);
+        
+        PropertyChangeEvent event1 = new PropertyChangeEvent("foo", 1, 2);
+        support.notifyHandlers(event1);
+        assertEquals(1, mh1.events.size());
+        assertEquals(event1, mh1.events.get(0));
+        
+        support.removePropertyChangeHandler(mh1);
+        
+        mh1.events.clear();;
+        
+        PropertyChangeEvent event2 = new PropertyChangeEvent("foo", 2, 3);
+        
+        support.notifyHandlers(event2);
+        assertEquals(0, mh1.events.size());
+    }
+    
+    
+    @Test
+    public void testNoChange(){
+        MockHandler mh1 = new MockHandler( );
+        support.addPropertyChangeHandler(mh1);
+        
+        support.notifyHandlers(new PropertyChangeEvent("foo", null, null));
+        support.notifyHandlers(new PropertyChangeEvent("foo", 1, 1));
+        support.notifyHandlers(new PropertyChangeEvent("foo", "test", "test"));
+        assertEquals(0, mh1.events.size());
+       
+       
+    }
+}

--- a/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/PropertyChangeHandlersIntegrationTest.java
+++ b/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/PropertyChangeHandlersIntegrationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2011 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.databinding.client.test;
+
+
+import org.jboss.errai.databinding.client.Model;
+import org.jboss.errai.databinding.client.api.DataBinder;
+import org.jboss.errai.ioc.client.test.AbstractErraiIOCTest;
+import org.junit.Test;
+
+import com.google.gwt.user.client.ui.TextBox;
+import org.jboss.errai.databinding.client.HasPropertyChangeHandlers;
+
+/**
+ * PropertyChangeHandling specific integration tests.
+ * 
+ * @author David Cracauer <dcracauer@gmail.com>
+ */
+public class PropertyChangeHandlersIntegrationTest extends AbstractErraiIOCTest {
+
+  @Override
+  public String getModuleName() {
+    return "org.jboss.errai.databinding.DataBindingTestModule";
+  }
+
+  @Override
+  protected void gwtSetUp() throws Exception {
+    super.gwtSetUp();
+  }
+
+  @Test
+  public void testBasicBinding() {
+    MockHandler handler = new MockHandler();
+    
+    TextBox textBox = new TextBox();
+    Model model = DataBinder.forType(Model.class).bind(textBox, "value").getModel();
+    
+    ((HasPropertyChangeHandlers)model).addPropertyChangeHandler(handler);
+
+    textBox.setValue("UI change", true);
+    assertEquals("Model not properly updated", "UI change", model.getValue());
+    assertEquals(1, handler.events.size());
+    assertEquals("value", handler.getEvents().get(0).getPropertyName());
+    assertEquals("UI change", handler.getEvents().get(0).getNewValue());
+    assertNull(handler.getEvents().get(0).getOldValue());
+
+    model.setValue("model change");
+    assertEquals("Widget not properly updated", "model change", textBox.getText());
+    assertEquals(2, handler.events.size());
+    assertEquals("value", handler.getEvents().get(1).getPropertyName());
+    assertEquals("model change", handler.getEvents().get(1).getNewValue());
+    assertEquals("UI change", handler.getEvents().get(1).getOldValue());
+    
+    
+  }
+  
+}


### PR DESCRIPTION
Allow for PropertyChange events to be dispatched and handled by a
BindableProxy (which now implements HasPropertyChangeHandlers)
