### PR TITLE
fix defect in EnvUtil

### DIFF
--- a/errai-config/src/main/java/org/jboss/errai/config/rebind/EnvUtil.java
+++ b/errai-config/src/main/java/org/jboss/errai/config/rebind/EnvUtil.java
@@ -151,7 +151,7 @@ public abstract class EnvUtil {
                 }
               }
 
-              break;
+              continue;
             }
 
             if (key.equals(CONFIG_ERRAI_NONSERIALIZABLE_TYPE)) {
@@ -164,7 +164,7 @@ public abstract class EnvUtil {
                 }
               }
 
-              break;
+              continue;
             }
 
             if (key.equals(CONFIG_ERRAI_MAPPING_ALIASES)) {
@@ -185,7 +185,7 @@ public abstract class EnvUtil {
                   throw new RuntimeException("could not find class defined in ErraiApp.properties for mapping: " + s);
                 }
               }
-              break;
+              continue;
             }
           }
         }


### PR DESCRIPTION
does not allow  CONFIG_ERRAI_SERIALIZABLE_TYPE,
CONFIG_ERRAI_NONSERIALIZABLE_TYPE, or CONFIG_ERRAI_MAPPING_ALIASES to
be used together in the same file.
