### PR TITLE
errai-bus should not require slf4j-log4j and log4j

### DIFF
--- a/errai-bus/pom.xml
+++ b/errai-bus/pom.xml
@@ -106,13 +106,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.1</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.1</version>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/errai-bus/src/main/java/org/jboss/errai/bus/server/service/ErraiServiceImpl.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/server/service/ErraiServiceImpl.java
@@ -18,7 +18,6 @@ package org.jboss.errai.bus.server.service;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.log4j.LogManager;
 import org.jboss.errai.bus.client.api.Message;
 import org.jboss.errai.bus.client.api.QueueSession;
 import org.jboss.errai.bus.client.api.builder.DefaultRemoteCallBuilder;

--- a/errai-cdi/demos/errai-cdi-mobile-demo/pom.xml
+++ b/errai-cdi/demos/errai-cdi-mobile-demo/pom.xml
@@ -241,10 +241,6 @@
           <artifactId>errai-bus</artifactId>
           <exclusions>
             <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
             </exclusion>

--- a/errai-cdi/demos/errai-cdi-mvp-demo/pom.xml
+++ b/errai-cdi/demos/errai-cdi-mvp-demo/pom.xml
@@ -237,10 +237,6 @@
           <artifactId>errai-bus</artifactId>
           <exclusions>
             <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
             </exclusion>

--- a/errai-cdi/demos/errai-cdi-stock-demo/pom.xml
+++ b/errai-cdi/demos/errai-cdi-stock-demo/pom.xml
@@ -232,10 +232,6 @@
           <artifactId>errai-bus</artifactId>
           <exclusions>
             <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
             </exclusion>

--- a/errai-cdi/demos/errai-cdi-stress-test/pom.xml
+++ b/errai-cdi/demos/errai-cdi-stress-test/pom.xml
@@ -232,10 +232,6 @@
           <artifactId>errai-bus</artifactId>
           <exclusions>
             <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
             </exclusion>

--- a/errai-cdi/demos/errai-cdi-tagcloud-demo/pom.xml
+++ b/errai-cdi/demos/errai-cdi-tagcloud-demo/pom.xml
@@ -231,10 +231,6 @@
           <artifactId>errai-bus</artifactId>
           <exclusions>
             <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
             </exclusion>

--- a/errai-cdi/weld-integration/pom.xml
+++ b/errai-cdi/weld-integration/pom.xml
@@ -392,6 +392,12 @@
                     <artifactId>slf4j-api</artifactId>
                     <version>${slf4j.version}</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <version>${slf4j.version}</version>
+                    <scope>test</scope>
+                </dependency>
 
                 <dependency>
                     <groupId>org.jboss</groupId>

--- a/errai-ioc/pom.xml
+++ b/errai-ioc/pom.xml
@@ -88,6 +88,13 @@ runtime dependencies on it and it breaks deployment on JBoss AS and Tomcat -->
 runtime dependencies on it and it breaks deployment on JBoss AS and Tomcat -->
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/errai-jpa/demos/errai-jpa-demo-basic/pom.xml
+++ b/errai-jpa/demos/errai-jpa-demo-basic/pom.xml
@@ -283,10 +283,6 @@
           <artifactId>errai-bus</artifactId>
           <exclusions>
             <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
             </exclusion>

--- a/errai-jpa/demos/errai-jpa-demo-grocery-list/pom.xml
+++ b/errai-jpa/demos/errai-jpa-demo-grocery-list/pom.xml
@@ -276,10 +276,6 @@
           <artifactId>errai-bus</artifactId>
           <exclusions>
             <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
             </exclusion>

--- a/errai-jpa/errai-jpa-client/pom.xml
+++ b/errai-jpa/errai-jpa-client/pom.xml
@@ -63,6 +63,13 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-gwt</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
     
   </dependencies>
 


### PR DESCRIPTION
errai-bus should not force the logging implementation slf4j-log4j on its users, who might want to use a logback (= log4J 2.0) or slf4j-simple. It should only use slf4j-log4j for its tests.
