### PR TITLE
Fix BigInteger and BigDecimal as Map key

### DIFF
--- a/errai-marshalling/src/main/java/org/jboss/errai/marshalling/client/marshallers/MapMarshaller.java
+++ b/errai-marshalling/src/main/java/org/jboss/errai/marshalling/client/marshallers/MapMarshaller.java
@@ -153,8 +153,8 @@ public class MapMarshaller<T extends Map<Object, Object>> implements Marshaller<
         buf.append("\"").append(entry.getKey()).append("\"");
       }
       else if (entry.getKey() != null) {
-        if (entry.getKey() instanceof Number || entry.getKey() instanceof Boolean
-            || entry.getKey() instanceof Character) {
+        if ((entry.getKey() instanceof Number && !(entry.getKey() instanceof BigInteger || entry.getKey() instanceof BigDecimal))
+        		|| entry.getKey() instanceof Boolean || entry.getKey() instanceof Character) {
           keyMarshaller = MarshallUtil.getQualifiedNumberMarshaller(entry.getKey());
         }
         else {

--- a/errai-marshalling/src/test/java/org/jboss/errai/marshalling/tests/ServerMarshallingTest.java
+++ b/errai-marshalling/src/test/java/org/jboss/errai/marshalling/tests/ServerMarshallingTest.java
@@ -3,11 +3,13 @@ package org.jboss.errai.marshalling.tests;
 import java.io.File;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.MathContext;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
@@ -342,6 +344,20 @@ public class ServerMarshallingTest {
   @Test
   public void testEmptyMap() {
     testEncodeDecodeDynamic(Collections.emptyMap());
+  }
+
+  @Test
+  public void testMapWithBigIntegerAsKey() {
+	  Map<BigInteger, String> map = new HashMap<BigInteger, String>();
+	  map.put(new BigInteger("10"), "10 value");
+	  testEncodeDecodeDynamic(map);
+  }
+
+  @Test
+  public void testMapWithBigDecimalAsKey() {
+	  Map<BigDecimal, String> map = new HashMap<BigDecimal, String>();
+	  map.put(new BigDecimal("10"), "10 value");
+	  testEncodeDecodeDynamic(map);
   }
 
   @Test


### PR DESCRIPTION
In MapMarshaller BigInteger and BigDecimal as maps key was encoded as number value resulting NullPointerException on demarshalling phaze.
