### PR TITLE
errai-navigation contribution: query params during navigation

### DIFF
--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/HistoryToken.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/HistoryToken.java
@@ -99,11 +99,15 @@ public class HistoryToken {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(URL.encodePathSegment(pageName));
-    sb.append(';');
-    for (Map.Entry<String, String> entry : state.entries()) {
-      sb.append(URL.encodePathSegment(entry.getKey()));
-      sb.append("=");
-      sb.append(URL.encodePathSegment(entry.getValue()));
+    if (!state.isEmpty()) {
+      boolean first = true;
+      for (Map.Entry<String, String> entry : state.entries()) {
+        sb.append(first ? ';' : '&');
+        sb.append(URL.encodePathSegment(entry.getKey()));
+        sb.append("=");
+        sb.append(URL.encodePathSegment(entry.getValue()));
+        first = false;
+      }
     }
     return sb.toString();
   }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
@@ -69,8 +69,9 @@ public class Navigation {
    */
   public <W extends Widget> void goTo(Class<W> toPage, Multimap<String,String> state) {
     PageNode<W> toPageInstance = navGraph.getPage(toPage);
-    show(toPageInstance, HistoryToken.of(toPageInstance.name(), state));
-    History.newItem(toPageInstance.name(), false); // TODO needs to be full history token
+    HistoryToken token = HistoryToken.of(toPageInstance.name(), state);
+    show(toPageInstance, token);
+    History.newItem(token.toString(), false);
   }
 
   /**

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageState.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageState.java
@@ -32,4 +32,10 @@ import java.lang.annotation.Target;
 @Documented
 public @interface PageState {
 
+  /**
+   * Provides a way to map the field name to a different value for the query parameter.  If
+   * not specified, the name of the field will be used as the name of the query parameter.
+   */
+  String value() default "";
+
 }


### PR DESCRIPTION
Fixed a problem with the HistoryToken toString().
Navigation params are now included in the history token when navigating.
@PageState allows alternate query param name mapping.
