### PR TITLE
ERRAI-231 : make the ModuleAnnotationProcessor eclipse-friendly

### DIFF
--- a/errai-common/pom.xml
+++ b/errai-common/pom.xml
@@ -96,4 +96,18 @@
         </dependency>
 
     </dependencies>
+    
+    <build>
+		<plugins>
+		      <plugin>
+		        <artifactId>maven-compiler-plugin</artifactId>
+		        <!-- javac should not try to apply the ModuleAnnotationProcessor defined in this project
+		        Enabled by default, it would fail the compilation in JDK 6 and worse, 
+		        would silently fail the compilation but not the build in JDK7 -->
+		        <configuration>
+		          <proc>none</proc>
+		        </configuration>
+		      </plugin>
+		</plugins>
+    </build>
 </project>

--- a/errai-common/src/main/java/org/jboss/errai/common/rebind/ModuleAnnotationProcessor.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/rebind/ModuleAnnotationProcessor.java
@@ -16,6 +16,16 @@
 
 package org.jboss.errai.common.rebind;
 
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -25,10 +35,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * @author Mike Brock
@@ -47,24 +53,59 @@ public class ModuleAnnotationProcessor extends AbstractProcessor {
     allKnownElements.addAll(roundEnvironment.getRootElements());
 
     if (roundEnvironment.processingOver()) {
-      final StringBuilder builder = new StringBuilder();
-      for (final Element e : allKnownElements) {
-        builder.append(e.toString()).append('\n');
-      }
 
+      final Set<String> currentElements = new LinkedHashSet<String>(allKnownElements.size());
+      Writer writer = null;
       try {
-        final FileObject fo
-                = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", "classlist.mf", null);
+        FileObject fo = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", "classlist.mf", null);
 
-        final Writer writer = fo.openWriter();
-        writer.write(builder.toString());
-        writer.close();
-      }
-      catch (IOException e) {
+        BufferedReader reader = null;
+        try {
+          File existingFile = new File(fo.toUri());
+          if (existingFile.canRead()) {
+            reader = new BufferedReader(new FileReader(existingFile));
+            String line;
+            while((line = reader.readLine()) != null) {
+              currentElements.add(line);
+            }
+          }
+        } finally {
+          closeQuietly(reader);
+        }
+
+        boolean hasContentChanged = false;
+        for (final Element e : allKnownElements) {
+          if (currentElements.add(e.toString())) {
+            hasContentChanged = true;
+          }
+        }
+
+        if (hasContentChanged) {
+          StringBuilder newContent = new StringBuilder();
+          for(String e : currentElements) {
+            newContent.append(e).append('\n');
+          }
+          writer = fo.openWriter();
+          writer.write(newContent.toString());
+        }
+
+      } catch (IOException e) {
         e.printStackTrace();
-      }
 
+      } finally {
+        closeQuietly(writer);
+      }
     }
     return false;
+  }
+
+  private void closeQuietly(Closeable closeable) {
+    if (closeable !=null) {
+      try {
+        closeable.close();
+      } catch (Exception e) {
+        //ignore
+      }
+    }
   }
 }

--- a/errai-common/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/errai-common/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.jboss.errai.common.rebind.ModuleAnnotationProcessor


### PR DESCRIPTION
- added a META-INF/services/javax.annotation.processing.Processor descriptor so that ModuleAnnotationProcessor can be invoked by eclipse APT.
- Keep the classlist.mf intact or update it during eclipse incremental builds
- prevent the project AP to being invoked on itself during CLI builds (could lead to baaad things with JDK 7)
