### PR TITLE
Added a new @Transition annotation to errai-navigation

### DIFF
--- a/errai-navigation/pom.xml
+++ b/errai-navigation/pom.xml
@@ -53,6 +53,13 @@
 
       <dependency>
          <groupId>org.jboss.errai</groupId>
+         <artifactId>errai-ui</artifactId>
+         <version>${project.version}</version>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.errai</groupId>
          <artifactId>errai-javax-enterprise</artifactId>
          <version>${project.version}</version>
          <scope>provided</scope>
@@ -110,6 +117,21 @@
          <groupId>org.jboss.errai</groupId>
          <artifactId>errai-weld-integration</artifactId>
          <version>${project.version}</version>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.errai</groupId>
+         <artifactId>errai-data-binding</artifactId>
+         <version>${project.version}</version>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.errai</groupId>
+         <artifactId>errai-ui</artifactId>
+         <version>${project.version}</version>
+         <classifier>sources</classifier>
          <scope>provided</scope>
       </dependency>
    </dependencies>

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/Navigation.gwt.xml
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/Navigation.gwt.xml
@@ -8,6 +8,8 @@
    <inherits name="org.jboss.errai.ioc.Container" />
    <inherits name="org.jboss.errai.enterprise.CDI" />
 
+   <inherits name="com.google.gwt.logging.Logging"/>
+
    <generate-with class="org.jboss.errai.ui.nav.rebind.NavigationGraphGenerator">
      <when-type-is class="org.jboss.errai.ui.nav.client.local.spi.NavigationGraph"/>
    </generate-with>

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Transition.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Transition.java
@@ -1,0 +1,32 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * This annotation only applies to fields of templated composite widgets that
+ * are of type {@link Anchor}. You can annotate such fields in order to indicate
+ * the target (href) of the Anchor. Errai Navigation will add the appropriate
+ * boilerplate code to implement navigation to the Errai Navigation page
+ * indicated in the annotation.
+ */
+@Inherited
+@Documented
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Transition {
+
+  /**
+   * Specify the target {@link Widget} Class that is annotated with @Page as the
+   * target of the navigation transition.
+   */
+  Class<? extends Widget> value();
+
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/DecoratorTransition.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/DecoratorTransition.java
@@ -1,0 +1,94 @@
+package org.jboss.errai.ui.nav.rebind;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.jboss.errai.codegen.Statement;
+import org.jboss.errai.codegen.exception.GenerationException;
+import org.jboss.errai.ioc.client.api.CodeDecorator;
+import org.jboss.errai.ioc.rebind.ioc.extension.IOCDecoratorExtension;
+import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectableInstance;
+import org.jboss.errai.ui.nav.client.local.Page;
+import org.jboss.errai.ui.nav.client.local.Transition;
+import org.jboss.errai.ui.rebind.DecoratorDataField;
+import org.jboss.errai.ui.rebind.DecoratorTemplated;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Handles {@link Transition} decorations.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@CodeDecorator
+public class DecoratorTransition extends IOCDecoratorExtension<Transition> {
+
+  private static final Logger logger = Logger.getLogger(DecoratorTransition.class.getName());
+
+  /**
+   * Constructor.
+   *
+   * @param decoratesWith
+   */
+  public DecoratorTransition(Class<Transition> decoratesWith) {
+    super(decoratesWith);
+  }
+
+  /**
+   * @see org.jboss.errai.ioc.rebind.ioc.extension.IOCDecoratorExtension#generateDecorator(org.jboss.errai.ioc.rebind.ioc.injector.api.InjectableInstance)
+   */
+  @Override
+  public List<? extends Statement> generateDecorator(
+          InjectableInstance<Transition> instance) {
+    Class<? extends Widget> transitionTargetClass = instance.getAnnotation()
+            .value();
+    Page transitionTargetPage = transitionTargetClass.getAnnotation(Page.class);
+    DataField dataField = instance.getField().getAnnotation(DataField.class);
+
+    // Can only transition to classes annotated with @Page
+    if (transitionTargetPage == null) {
+      throw new GenerationException("@Transition ["
+              + instance.getEnclosingType().getFullyQualifiedName() + "."
+              + instance.getField().getName() + "] targets class ["
+              + transitionTargetClass.getSimpleName()
+              + "] which is not annotated by @Page");
+    }
+    // Currently only support Anchors as transitions
+    if (!instance.getType().isAssignableTo(Anchor.class)) {
+      throw new GenerationException(
+              "@Transition ["
+                      + transitionTargetClass.getSimpleName()
+                      + "] applies to field ["
+                      + instance.getField().getName()
+                      + "] of class["
+                      + instance.getEnclosingType().getFullyQualifiedName()
+                      + "] but the field type is *not* com.google.gwt.user.client.ui.Anchor");
+    }
+    // The field must also be a data field from errai-ui templating
+    if (dataField == null) {
+      throw new GenerationException("@Transition ["
+              + instance.getEnclosingType().getFullyQualifiedName() + "."
+              + instance.getField().getName()
+              + "] must also be annotated with @DataField");
+    }
+
+    String transitionTargetPageName = transitionTargetPage.path().equals("") ? transitionTargetClass
+            .getName() : transitionTargetPage.path();
+    String historyToken = "#" + transitionTargetPageName;
+    logger.info("Setting @Transition annotated Anchor ["
+            + instance.getEnclosingType().getFullyQualifiedName() + "."
+            + instance.getField().getName() + "]'s href attribute to ["
+            + historyToken + "].");
+
+    String dataFieldName = DecoratorDataField.getTemplateDataFieldName(
+            dataField, instance.getMemberName());
+
+    DecoratorTemplated.setAttributeOverride(instance, dataFieldName, "href",
+            historyToken);
+    return Collections.emptyList();
+  }
+
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
@@ -43,6 +43,7 @@ import org.jboss.errai.ui.nav.client.local.Page;
 import org.jboss.errai.ui.nav.client.local.PageHiding;
 import org.jboss.errai.ui.nav.client.local.PageShowing;
 import org.jboss.errai.ui.nav.client.local.PageState;
+import org.jboss.errai.ui.nav.client.local.Transition;
 import org.jboss.errai.ui.nav.client.local.TransitionTo;
 import org.jboss.errai.ui.nav.client.local.spi.NavigationGraph;
 import org.jboss.errai.ui.nav.client.local.spi.PageNode;
@@ -359,6 +360,14 @@ public class NavigationGraphGenerator extends Generator {
 
             // entry for the link between nodes
             out.println("\"" + pageName + "\" -> \"" + targetPageName + "\" [label=\"" + field.getName() + "\"]");
+          } else if (field.getAnnotation(Transition.class) != null) {
+              Transition t = field.getAnnotation(Transition.class);
+              Class<? extends Widget> targetClass = t.value();
+              Page page = targetClass.getAnnotation(Page.class);
+              String targetPageName = page.path() == null ? targetClass.getSimpleName() : page.path();
+
+              // entry for the link between nodes
+              out.println("\"" + pageName + "\" -> \"" + targetPageName + "\" [label=\"" + field.getName() + "\"]");
           }
         }
       }

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/TransitionTest.gwt.xml
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/TransitionTest.gwt.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
+        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+<module>
+
+   <inherits name="org.jboss.errai.ui.UI" />
+   <inherits name="org.jboss.errai.ui.nav.Navigation" />
+
+   <source path="client"/>
+
+</module>

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/TransitionTest.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/TransitionTest.java
@@ -1,0 +1,36 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import org.jboss.errai.enterprise.client.cdi.AbstractErraiCDITest;
+import org.jboss.errai.ioc.client.container.IOC;
+import org.jboss.errai.ioc.client.container.IOCBeanManager;
+import org.jboss.errai.ui.nav.client.local.testpages.PageWithTransitionA;
+
+import com.google.gwt.user.client.ui.Anchor;
+
+public class TransitionTest extends AbstractErraiCDITest {
+
+  private IOCBeanManager beanManager = IOC.getBeanManager();
+
+  @Override
+  public String getModuleName() {
+    return "org.jboss.errai.ui.nav.TransitionTest";
+  }
+
+  @Override
+  protected void gwtSetUp() throws Exception {
+    disableBus = true;
+    super.gwtSetUp();
+  }
+
+  public void testLinkHrefIsSet() throws Exception {
+    PageWithTransitionA page = beanManager.lookupBean(PageWithTransitionA.class).getInstance();
+    Anchor linkToB = page.linkToB;
+
+    // The 'href' attribute in the template is "otherpage.html" - but the framework
+    // should have replaced that with #page_b, which is the path attribute of the
+    // @Page annotation in the PageB class.
+    assertNotNull(linkToB);
+    assertTrue("Expected the linkToB anchor to end with #page_b (the 'path' attribute on the @Page annotation on the PageB class)", 
+            linkToB.getHref().endsWith("#page_b"));
+  }
+}

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithTransitionA.html
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithTransitionA.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Page With Transition (A)</title>
+  </head>
+  <body>
+    <div data-field="page">
+      <h1>Page With Transition (A)</h1>
+      <div>
+        <a data-field="linkToB" href="otherpage.html">Go To B</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithTransitionA.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithTransitionA.java
@@ -1,0 +1,22 @@
+package org.jboss.errai.ui.nav.client.local.testpages;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.nav.client.local.Page;
+import org.jboss.errai.ui.nav.client.local.Transition;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.Composite;
+
+@Dependent
+@Page(path="pwtA")
+@Templated("#page")
+public class PageWithTransitionA extends Composite {
+
+  @Inject @DataField("linkToB") @Transition(PageB.class)
+  public Anchor linkToB;
+
+}

--- a/errai-ui/src/main/java/org/jboss/errai/ui/rebind/DecoratorDataField.java
+++ b/errai-ui/src/main/java/org/jboss/errai/ui/rebind/DecoratorDataField.java
@@ -77,7 +77,7 @@ public class DecoratorDataField extends IOCDecoratorExtension<DataField> {
     dataFieldTypeMap(ctx, ctx.getEnclosingType()).put(name, type);
   }
 
-  private String getTemplateDataFieldName(DataField annotation, String deflt) {
+  public static String getTemplateDataFieldName(DataField annotation, String deflt) {
     String value = Strings.nullToEmpty(annotation.value()).trim();
     return value.isEmpty() ? deflt : value;
   }

--- a/errai-ui/src/main/java/org/jboss/errai/ui/shared/TemplateUtil.java
+++ b/errai-ui/src/main/java/org/jboss/errai/ui/shared/TemplateUtil.java
@@ -94,6 +94,16 @@ public final class TemplateUtil {
     }
   }
 
+  /**
+   * Overrides the value of a single attribute on a widget.
+   * @param field
+   * @param attributeName
+   * @param attributeValue
+   */
+  public static void overrideAttribute(Widget field, String attributeName, String attributeValue) {
+    field.getElement().setAttribute(attributeName, attributeValue);
+  }
+
   public static void initWidget(Composite component, Element wrapped, Collection<Widget> dataFields) {
     initWidgetNative(component, new TemplateWidget(wrapped, dataFields));
     DOM.setEventListener(component.getElement(), component);


### PR DESCRIPTION
Added support for a new @Transition annotation which can be used on
fields annotated as @DataField (and of type Anchor).  This allows static
linking to @Pages without any boilerplate code at all.  See additional 
comments (to follow).
