### PR TITLE
initial version of the errai-cordova module adds the posible to specify ...

### DIFF
--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/framework/ClientMessageBusImpl.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/framework/ClientMessageBusImpl.java
@@ -237,7 +237,7 @@ public class ClientMessageBusImpl implements ClientMessageBus {
           final RequestCallback callback) throws RequestException {
     final RequestBuilder builder = new RequestBuilder(
         method,
-        URL.encode(getApplicationRoot() + serviceEntryPoint) + "?z=" + getNextRequestNumber()
+        URL.encode(getApplicationLocation(serviceEntryPoint)) + "?z=" + getNextRequestNumber()
     );
 
     builder.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -1965,6 +1965,10 @@ public class ClientMessageBusImpl implements ClientMessageBus {
       $wnd.erraiBusApplicationRoot = path;
     }
   }-*/;
+
+  protected String getApplicationLocation(String serviceEntryPoint) {
+    return getApplicationRoot() + serviceEntryPoint;
+  }
 
   /**
    * Returns the application root for the remote message bus endpoints.

--- a/errai-cordova/pom.xml
+++ b/errai-cordova/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2011 JBoss, by Red Hat, Inc ~ ~ Licensed under the Apache 
+   License, Version 2.0 (the "License"); ~ you may not use this file except 
+   in compliance with the License. ~ You may obtain a copy of the License at 
+   ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by applicable 
+   law or agreed to in writing, software ~ distributed under the License is 
+   distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY 
+   KIND, either express or implied. ~ See the License for the specific language 
+   governing permissions and ~ limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <parent>
+      <artifactId>errai-parent</artifactId>
+      <groupId>org.jboss.errai</groupId>
+      <version>2.2.0-SNAPSHOT</version>
+   </parent>
+   <modelVersion>4.0.0</modelVersion>
+
+   <artifactId>errai-cordova</artifactId>
+   <name>Errai::Cordova</name>
+
+	<properties>
+        <junit.version>4.8.1</junit.version>
+	</properties>
+
+   <dependencies>
+       <dependency>
+           <groupId>org.jboss.errai</groupId>
+           <artifactId>errai-bus</artifactId>
+           <version>${project.version}</version>
+       </dependency>
+
+       <!-- GWT -->
+       <dependency>
+           <groupId>com.google.gwt</groupId>
+           <artifactId>gwt-user</artifactId>
+           <scope>provided</scope>
+       </dependency>
+
+       <dependency>
+           <groupId>com.google.gwt</groupId>
+           <artifactId>gwt-dev</artifactId>
+           <scope>provided</scope>
+       </dependency>
+
+       <!-- Test Deps -->
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+         <scope>provided</scope>
+      </dependency>
+
+   </dependencies>
+
+   <profiles>
+      <profile>
+         <id>integration-test</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <skipTests>false</skipTests>
+                     <forkMode>always</forkMode>
+                     <argLine>-Xmx1500m ${argLine}</argLine>
+
+                     <additionalClasspathElements>
+                        <additionalClasspathElement>${basedir}/target/classes/</additionalClasspathElement>
+                        <additionalClasspathElement>${basedir}/test-classes/</additionalClasspathElement>
+                        <additionalClasspathElement>${basedir}/src/main/java/</additionalClasspathElement>
+                        <additionalClasspathElement>${basedir}/src/test/java/</additionalClasspathElement>
+                     </additionalClasspathElements>
+                     <useSystemClassLoader>false</useSystemClassLoader>
+                     <useManifestOnlyJar>true</useManifestOnlyJar>
+
+                     <systemProperties>
+                        <property>
+                           <name>java.io.tmpdir</name>
+                           <value>${project.build.directory}</value>
+                        </property>
+                        <property>
+                           <name>log4j.output.dir</name>
+                           <value>${project.build.directory}</value>
+                        </property>
+
+                        <!-- Do not accidently package server test marshallers 
+                           when building Errai -->
+                        <property>
+                           <name>errai.marshalling.server.classOutput.enabled</name>
+                           <value>false</value>
+                        </property>
+
+
+                        <!-- Must disable long polling for automated tests 
+                           to succeed -->
+                        <property>
+                           <name>org.jboss.errai.bus.do_long_poll</name>
+                           <value>false</value>
+                        </property>
+
+                        <!-- Disable caching of generated code -->
+                        <property>
+                           <name>errai.devel.nocache</name>
+                           <value>true</value>
+                        </property>
+                     </systemProperties>
+
+                     <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                     </includes>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
+
+</project>

--- a/errai-cordova/src/main/java/org/jboss/errai/ui/Cordova.gwt.xml
+++ b/errai-cordova/src/main/java/org/jboss/errai/ui/Cordova.gwt.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2011 JBoss, by Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.0//EN"
+        "http://google-web-toolkit.googlecode.com/svn/releases/2.0/distro-source/core/src/gwt-module.dtd">
+<module>
+  <define-property name="configured" values="true, false" />
+
+  <replace-with class="org.jboss.errai.ui.cordova.Configuration.Dummy">
+    <when-type-is class="org.jboss.errai.ui.cordova.Configuration"/>
+  </replace-with>
+
+  <replace-with class="org.jboss.errai.ui.cordova.LocationAwareClientMessageBus">
+    <when-type-is class="org.jboss.errai.bus.client.framework.MessageBus"/>
+  </replace-with>
+
+  <source path="cordova" />
+  <source path="shared" />
+</module>

--- a/errai-cordova/src/main/java/org/jboss/errai/ui/cordova/Configuration.java
+++ b/errai-cordova/src/main/java/org/jboss/errai/ui/cordova/Configuration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2011 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.cordova;
+
+/**
+ * Configuration interface to specify server location url
+ *
+ * @author Erik Jan de Wit
+ */
+public interface Configuration {
+
+  String getRemoteLocation();
+
+  public class Dummy implements Configuration {
+
+    @Override
+    public String getRemoteLocation() {
+      return "";
+    }
+  }
+}

--- a/errai-cordova/src/main/java/org/jboss/errai/ui/cordova/LocationAwareClientMessageBus.java
+++ b/errai-cordova/src/main/java/org/jboss/errai/ui/cordova/LocationAwareClientMessageBus.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2011 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.cordova;
+
+import com.google.gwt.core.client.GWT;
+import org.jboss.errai.bus.client.framework.ClientMessageBusImpl;
+
+import java.util.logging.Logger;
+
+/**
+ * Overrides the standard ClientMessageBus implementation in a way that the user can specify the address of the server.
+ *
+ * @author Erik Jan de Wit
+ */
+public class LocationAwareClientMessageBus extends ClientMessageBusImpl {
+  private static final Logger LOG = Logger.getLogger(LocationAwareClientMessageBus.class.getName());
+  private Configuration configuration;
+
+  @Override
+  protected String getApplicationLocation(String serviceEntryPoint) {
+    configuration = getConfiguration();
+    if (configuration instanceof Configuration.Dummy) {
+      throw new IllegalArgumentException("you need to implement Configuration in order to point to the server location");
+    }
+
+    LOG.info("url end point " + configuration.getRemoteLocation());
+
+    return configuration.getRemoteLocation() + serviceEntryPoint;
+  }
+
+  private Configuration getConfiguration() {
+    if (configuration == null) {
+      configuration = GWT.create(Configuration.class);
+    }
+    return configuration;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <module>errai-javaee-all</module>
         <module>errai-config</module>
         <module>errai-codegen-gwt</module>
+        <module>errai-cordova</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
...the location of the message bus

By implementing the Configuration one can specify the location of the server in <module>.gwt.xml

```
<replace-with class="org.jboss.errai.example.client.local.Config">
    <when-type-is class="org.jboss.errai.ui.cordova.Configuration"/>
</replace-with>
```
