### PR TITLE
Feature Proposal: new TransitionAnchor widget in errai-navigation

### DIFF
--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/TransitionAnchor.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/TransitionAnchor.java
@@ -1,0 +1,91 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import org.jboss.errai.common.client.api.Assert;
+import org.jboss.errai.ui.nav.client.local.spi.PageNode;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Represents an anchor widget that, when clicked, will navigate the user
+ * to another page in the application's flow.
+ * <p>
+ * Instances of this class are normally obtained via dependency injection.
+ * <p>
+ * Instances of this class are immutable.
+ *
+ * @param <P> The type of the target page ("to page")
+ * @author eric.wittmann@redhat.com
+ */
+public final class TransitionAnchor<P extends Widget> extends Anchor implements ClickHandler {
+
+  private final Navigation navigation;
+  private final Class<P> toPageWidgetType;
+
+  /**
+   * Creates a new TransitionAnchor with the given attributes.
+   *
+   * @param navigation
+   *          The navigation system this page transition participates in.
+   * @param toPage
+   *          The page type this transition goes to. Not null.
+   * @throws NullPointerException
+   *           if any of the arguments are null.
+   */
+  TransitionAnchor(Navigation navigation, Class<P> toPage) {
+    this.navigation = Assert.notNull(navigation);
+    this.toPageWidgetType = Assert.notNull(toPage);
+    addClickHandler(this);
+    initHref(toPage);
+  }
+
+  /**
+   * Initialize the anchor's href attribute.
+   *
+   * @param toPage
+   *          The page type this transition goes to. Not null.
+   */
+  private void initHref(Class<P> toPage) {
+    PageNode<P> toPageInstance = navigation.getNavGraph().getPage(toPage);
+    HistoryToken token = HistoryToken.of(toPageInstance.name(), ImmutableMultimap.<String,String>of());
+    String href = "#" + token.toString();
+    setHref(href);
+  }
+
+  /**
+   * The page this transition goes to.
+   */
+  public Class<P> toPageType() {
+    return toPageWidgetType;
+  }
+
+  /**
+   * @see com.google.gwt.event.dom.client.ClickHandler#onClick(com.google.gwt.event.dom.client.ClickEvent)
+   */
+  @Override
+  public void onClick(ClickEvent event) {
+    navigation.goTo(toPageWidgetType, ImmutableMultimap.<String,String>of());
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+  /**
+   * Programmatically click on the anchor.
+   */
+  public void click() {
+    navigation.goTo(toPageWidgetType, ImmutableMultimap.<String,String>of());
+  }
+
+  /**
+   * Programmatically click on the anchor (with some parameters).
+   * @param state
+   */
+  public void click(Multimap<String,String> state) {
+    navigation.goTo(toPageWidgetType, state);
+  }
+
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorProvider.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorProvider.java
@@ -1,0 +1,30 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import java.lang.annotation.Annotation;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.errai.ioc.client.api.ContextualTypeProvider;
+import org.jboss.errai.ioc.client.api.IOCProvider;
+
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Provides new instances of the {@link TransitionAnchor} widget class, which
+ * allows them to be injected.
+ * @author eric.wittmann@redhat.com
+ */
+@IOCProvider @Singleton
+public class TransitionAnchorProvider implements ContextualTypeProvider<TransitionAnchor<?>> {
+
+  @Inject Navigation navigation;
+
+  @Override
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public TransitionAnchor provide(Class<?>[] typeargs, Annotation[] qualifiers) {
+    Class<Widget> toPageType = (Class<Widget>) typeargs[0];
+    return new TransitionAnchor<Widget>(navigation, toPageType);
+  }
+
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
@@ -43,6 +43,7 @@ import org.jboss.errai.ui.nav.client.local.Page;
 import org.jboss.errai.ui.nav.client.local.PageHiding;
 import org.jboss.errai.ui.nav.client.local.PageShowing;
 import org.jboss.errai.ui.nav.client.local.PageState;
+import org.jboss.errai.ui.nav.client.local.TransitionAnchor;
 import org.jboss.errai.ui.nav.client.local.TransitionTo;
 import org.jboss.errai.ui.nav.client.local.spi.NavigationGraph;
 import org.jboss.errai.ui.nav.client.local.spi.PageNode;
@@ -341,6 +342,7 @@ public class NavigationGraphGenerator extends Generator {
       out = new PrintWriter(dotFile);
       out.println("digraph Navigation {");
       final MetaClass transitionToType = MetaClassFactory.get(TransitionTo.class);
+      final MetaClass transitionAnchorType = MetaClassFactory.get(TransitionAnchor.class);
       for (Map.Entry<String, MetaClass> entry : pages.entrySet()) {
         String pageName = entry.getKey();
         MetaClass pageClass = entry.getValue();
@@ -353,7 +355,7 @@ public class NavigationGraphGenerator extends Generator {
         out.println();
 
         for (MetaField field : getAllFields(pageClass)) {
-          if (field.getType().getErased().equals(transitionToType)) {
+          if (field.getType().getErased().equals(transitionToType) || field.getType().getErased().equals(transitionAnchorType)) {
             MetaType targetPageType = field.getType().getParameterizedType().getTypeParameters()[0];
             String targetPageName = pages.inverse().get(targetPageType);
 

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorTest.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorTest.java
@@ -1,0 +1,31 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import org.jboss.errai.enterprise.client.cdi.AbstractErraiCDITest;
+import org.jboss.errai.ioc.client.container.IOC;
+import org.jboss.errai.ioc.client.container.IOCBeanManager;
+import org.jboss.errai.ui.nav.client.local.testpages.PageWithTransitionAnchor;
+
+public class TransitionAnchorTest extends AbstractErraiCDITest {
+
+  private IOCBeanManager beanManager = null;
+
+  @Override
+  public String getModuleName() {
+    return "org.jboss.errai.ui.nav.NavigationTest";
+  }
+
+  @Override
+  protected void gwtSetUp() throws Exception {
+    disableBus = true;
+    super.gwtSetUp();
+    beanManager = IOC.getBeanManager();
+  }
+
+  public void testTransitionAnchorInjection() throws Exception {
+    PageWithTransitionAnchor page = beanManager.lookupBean(PageWithTransitionAnchor.class).getInstance();
+    assertNotNull(page);
+    assertNotNull(page.linkToB.getHref());
+    assertTrue(page.linkToB.getHref().endsWith("#page_b"));
+  }
+
+}

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithTransitionAnchor.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithTransitionAnchor.java
@@ -1,0 +1,18 @@
+package org.jboss.errai.ui.nav.client.local.testpages;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.nav.client.local.Page;
+import org.jboss.errai.ui.nav.client.local.TransitionAnchor;
+
+import com.google.gwt.user.client.ui.SimplePanel;
+
+@Dependent
+@Page
+public class PageWithTransitionAnchor extends SimplePanel {
+
+  @Inject
+  public TransitionAnchor<PageB> linkToB;
+
+}


### PR DESCRIPTION
#### Description

Created a new injectable widget called TransitionAnchor.  This widget extends GWT's Anchor and includes the navigation boilerplate, allowing simple links to be made from Page to Page within errai-navigation.

Example:

``` java
@Templated("site/dashboard.html#page")
@Page(path="dashboard", startingPage=true)
@Dependent
public class DashboardPage extends Composite {
    @Inject @DataField("aboutLink")
    private TransitionAnchor<AboutPage> aboutLink;
}
```

The above will inject an Anchor widget that, when clicked, will navigate to AboutPage.
#### What's Missing

Currently the "href" attribute of the Anchor widget is being properly set to the target page's history token.  However, errai-ui's Templating system will whack the 'href' attribute and replace it with whatever is in the template.  I'll bring this up in the forum or IRC to discuss possible solutions.
