### PR TITLE
fixed ERRAI-470 - errai-cdi-stress-test is leaking a thread after undeploy

### DIFF
--- a/errai-cdi/demos/errai-cdi-stress-test/src/main/java/org/jboss/errai/cdi/test/stress/server/SimpleCDIService.java
+++ b/errai-cdi/demos/errai-cdi-stress-test/src/main/java/org/jboss/errai/cdi/test/stress/server/SimpleCDIService.java
@@ -128,4 +128,9 @@ public class SimpleCDIService {
 
     currentConfiguration = config;
   }
+  
+  @PreDestroy
+  public void stopTicker() {
+	  tickMaker.shutdown();
+  }  
 }


### PR DESCRIPTION
fix for  ERRAI-470
