### PR TITLE
TransitionAnchors with additional @PageState

### DIFF
--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorFactory.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorFactory.java
@@ -1,0 +1,73 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import org.jboss.errai.common.client.api.Assert;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * A factory for creating {@link TransitionAnchor} instances.  This is
+ * useful when, for example, showing a list of items that each are hyperlinked
+ * to the same {@link Page} but with different {@link PageState}.
+ *
+ * @param <P> The type of the target page ("to page")
+ * @author eric.wittmann@redhat.com
+ */
+public final class TransitionAnchorFactory<P extends Widget> {
+
+  private final Navigation navigation;
+  private final Class<P> toPageWidgetType;
+
+  /**
+   * Creates a new {@link TransitionAnchorFactory}.
+   *
+   * @param navigation
+   *          The navigation system this page transition participates in.
+   * @param toPage
+   *          The page type this transition goes to. Not null.
+   * @throws NullPointerException
+   *           if any of the arguments are null.
+   */
+  TransitionAnchorFactory(Navigation navigation, final Class<P> toPage) {
+    this.navigation = Assert.notNull(navigation);
+    this.toPageWidgetType = Assert.notNull(toPage);
+  }
+
+  /**
+   * Gets an instance of a {@link TransitionAnchor} without any additional
+   * {@link PageState}.
+   */
+  public TransitionAnchor<P> get() {
+    return new TransitionAnchor<P>(navigation, toPageWidgetType);
+  }
+
+  /**
+   * Gets an instance of a {@link TransitionAnchor} with the given {@link PageState}.
+   * @param state
+   */
+  public TransitionAnchor<P> get(Multimap<String, String> state) {
+    return new TransitionAnchor<P>(navigation, toPageWidgetType, state);
+  }
+
+  /**
+   * Gets an instance of a {@link TransitionAnchor} with the given single piece of
+   * {@link PageState}.  This is a convenience for the use-case where the target
+   * {@link Page} has a single piece of state, such as a UUID.
+   * @param stateKey
+   * @param stateValue
+   */
+  public TransitionAnchor<P> get(String stateKey, String stateValue) {
+    Multimap<String, String> state = HashMultimap.create();
+    state.put(stateKey, stateValue);
+    return new TransitionAnchor<P>(navigation, toPageWidgetType, state);
+  }
+
+  /**
+   * The page this transition goes to.
+   */
+  public Class<P> toPageType() {
+    return toPageWidgetType;
+  }
+
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorFactoryProvider.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorFactoryProvider.java
@@ -1,0 +1,30 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import java.lang.annotation.Annotation;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.errai.ioc.client.api.ContextualTypeProvider;
+import org.jboss.errai.ioc.client.api.IOCProvider;
+
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Provides new instances of the {@link TransitionAnchorFactory} class, which
+ * allows them to be injected.
+ * @author eric.wittmann@redhat.com
+ */
+@IOCProvider @Singleton
+public class TransitionAnchorFactoryProvider implements ContextualTypeProvider<TransitionAnchorFactory<?>> {
+
+  @Inject Navigation navigation;
+
+  @Override
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public TransitionAnchorFactory provide(Class<?>[] typeargs, Annotation[] qualifiers) {
+    Class<Widget> toPageType = (Class<Widget>) typeargs[0];
+    return new TransitionAnchorFactory<Widget>(navigation, toPageType);
+  }
+
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
@@ -49,6 +49,7 @@ import org.jboss.errai.ui.nav.client.local.PageShowing;
 import org.jboss.errai.ui.nav.client.local.PageShown;
 import org.jboss.errai.ui.nav.client.local.PageState;
 import org.jboss.errai.ui.nav.client.local.TransitionAnchor;
+import org.jboss.errai.ui.nav.client.local.TransitionAnchorFactory;
 import org.jboss.errai.ui.nav.client.local.TransitionTo;
 import org.jboss.errai.ui.nav.client.local.spi.NavigationGraph;
 import org.jboss.errai.ui.nav.client.local.spi.PageNode;
@@ -383,6 +384,7 @@ public class NavigationGraphGenerator extends Generator {
       out.println("digraph Navigation {");
       final MetaClass transitionToType = MetaClassFactory.get(TransitionTo.class);
       final MetaClass transitionAnchorType = MetaClassFactory.get(TransitionAnchor.class);
+      final MetaClass transitionAnchorFactoryType = MetaClassFactory.get(TransitionAnchorFactory.class);
       for (Map.Entry<String, MetaClass> entry : pages.entrySet()) {
         String pageName = entry.getKey();
         MetaClass pageClass = entry.getValue();
@@ -395,7 +397,9 @@ public class NavigationGraphGenerator extends Generator {
         out.println();
 
         for (MetaField field : getAllFields(pageClass)) {
-          if (field.getType().getErased().equals(transitionToType) || field.getType().getErased().equals(transitionAnchorType)) {
+          if (field.getType().getErased().equals(transitionToType)
+                  || field.getType().getErased().equals(transitionAnchorType)
+                  || field.getType().getErased().equals(transitionAnchorFactoryType)) {
             MetaType targetPageType = field.getType().getParameterizedType().getTypeParameters()[0];
             String targetPageName = pages.inverse().get(targetPageType);
 

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorTest.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/TransitionAnchorTest.java
@@ -26,8 +26,25 @@ public class TransitionAnchorTest extends AbstractErraiCDITest {
     assertNotNull(app);
     PageWithTransitionAnchor page = app.getPage();
     assertNotNull(page);
+
+    // Ensure that an injected TransitionAnchor works
     assertNotNull(page.linkToB.getHref());
     assertTrue(page.linkToB.getHref().endsWith("#page_b"));
+
+    // Now ensure that an injected TransitionAnchorFactory works
+    assertEquals(4, page.getWidgetCount());
+    // TransitionAnchor from factory #1
+    TransitionAnchor<?> factoryAnchor = (TransitionAnchor<?>) page.getWidget(1);
+    assertNotNull(factoryAnchor);
+    assertTrue(factoryAnchor.getHref().endsWith("#page_b_with_state"));
+    // TransitionAnchor from factory #2
+    factoryAnchor = (TransitionAnchor<?>) page.getWidget(2);
+    assertNotNull(factoryAnchor);
+    assertTrue(factoryAnchor.getHref().endsWith("#page_b_with_state;uuid=12345"));
+    // TransitionAnchor from factory #3
+    factoryAnchor = (TransitionAnchor<?>) page.getWidget(3);
+    assertNotNull(factoryAnchor);
+    assertTrue(factoryAnchor.getHref().endsWith("#page_b_with_state;uuid=54321"));
   }
 
 }

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageBWithState.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageBWithState.java
@@ -1,0 +1,23 @@
+package org.jboss.errai.ui.nav.client.local.testpages;
+
+import javax.enterprise.context.Dependent;
+
+import org.jboss.errai.ui.nav.client.local.Page;
+import org.jboss.errai.ui.nav.client.local.PageState;
+
+import com.google.gwt.user.client.ui.SimplePanel;
+
+@Dependent
+@Page(path="page_b_with_state")
+public class PageBWithState extends SimplePanel {
+
+  @PageState
+  public String uuid;
+
+  /**
+   * Constructor.
+   */
+  public PageBWithState() {
+  }
+
+}

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithTransitionAnchor.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithTransitionAnchor.java
@@ -6,15 +6,20 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ui.nav.client.local.Page;
 import org.jboss.errai.ui.nav.client.local.TransitionAnchor;
+import org.jboss.errai.ui.nav.client.local.TransitionAnchorFactory;
 
-import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.common.collect.HashMultimap;
+import com.google.gwt.user.client.ui.FlowPanel;
 
 @Dependent
 @Page
-public class PageWithTransitionAnchor extends SimplePanel {
+public class PageWithTransitionAnchor extends FlowPanel {
 
   @Inject
   public TransitionAnchor<PageB> linkToB;
+
+  @Inject
+  public TransitionAnchorFactory<PageBWithState> linkFactory;
 
   /**
    * Constructor.
@@ -25,6 +30,11 @@ public class PageWithTransitionAnchor extends SimplePanel {
   @PostConstruct
   protected void postCtor() {
     add(linkToB);
+    add(linkFactory.get());
+    add(linkFactory.get("uuid", "12345"));
+    HashMultimap<String, String> state = HashMultimap.create();
+    state.put("uuid", "54321");
+    add(linkFactory.get(state));
   }
 
 }


### PR DESCRIPTION
Added a new TransitionAnchorFactory that can be @Injected and then used
to create TransitionAnchors programmatically in applications.  In
particular, this solves the problem where an application might display a
list of items in a Table, with each item linked to another Page in the
application with different @PageState (e.g. a UUID).
