### PR TITLE
Remove unreachable logging statement

### DIFF
--- a/errai-marshalling/src/main/java/org/jboss/errai/marshalling/rebind/MarshallersGenerator.java
+++ b/errai-marshalling/src/main/java/org/jboss/errai/marshalling/rebind/MarshallersGenerator.java
@@ -217,11 +217,6 @@ public class MarshallersGenerator extends AbstractAsyncGenerator {
   @Override
   public String generate(final TreeLogger logger, final GeneratorContext context, final String typeName)
       throws UnableToCompleteException {
-
-    if (GWT.isProdMode()) {
-      log.info("compiling in production mode.");
-    }
-
     logger.log(TreeLogger.INFO, "Generating Marshallers Bootstrapper...");
     return startAsyncGeneratorsAndWaitFor(MarshallerFactory.class, context, logger, packageName, className);
   }


### PR DESCRIPTION
GWT.isProdMode() always returns false. It will only be replaced by the GWT compiler which will never happen for rebind code.
