### PR TITLE
Fix a new line preventing the jpa-demo-grocery-list to run.

### DIFF
--- a/errai-demos/errai-jpa-demo-grocery-list/pom.xml
+++ b/errai-demos/errai-jpa-demo-grocery-list/pom.xml
@@ -692,7 +692,7 @@
                     <logLevel>INFO</logLevel>
                     <runTarget>index.html</runTarget>
                     <extraJvmArgs>${argLine} -Xmx1g -Xms1g -XX:MaxPermSize=200m -XX:+AggressiveOpts -XX:CompileThreshold=100
-                        -XX:+UseNUMA</extraJvmArgs>
+-XX:+UseNUMA</extraJvmArgs>
                     <soyc>false</soyc>
                     <hostedWebapp>src/main/webapp/</hostedWebapp>
                     <server>org.jboss.errai.cdi.server.gwt.JettyLauncher</server>


### PR DESCRIPTION
With the new line I get the following error:
[ERROR] /bin/sh: line 1: -XX:+UseNUMA: command not found
