### PR TITLE
Ensured same behavior of MetaClass#get*Fields() implementations.

### DIFF
--- a/errai-codegen-gwt/src/main/java/org/jboss/errai/codegen/meta/impl/gwt/GWTClass.java
+++ b/errai-codegen-gwt/src/main/java/org/jboss/errai/codegen/meta/impl/gwt/GWTClass.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.collect.Lists;
 import org.jboss.errai.codegen.DefModifiers;
 import org.jboss.errai.codegen.Parameter;
 import org.jboss.errai.codegen.builder.impl.Scope;
@@ -269,16 +270,6 @@ public class GWTClass extends AbstractMetaClass<JType> {
     return fromMethodArray(oracle, type.getMethods());
   }
 
-  private static MetaField[] fromFieldArray(final TypeOracle oracle, final JField[] methods) {
-    final List<MetaField> methodList = new ArrayList<MetaField>();
-
-    for (final JField f : methods) {
-      methodList.add(new GWTField(oracle, f));
-    }
-
-    return methodList.toArray(new MetaField[methodList.size()]);
-  }
-
   @Override
   public MetaClass getErased() {
     if (getParameterizedType() == null) {
@@ -291,16 +282,33 @@ public class GWTClass extends AbstractMetaClass<JType> {
 
   @Override
   public MetaField[] getFields() {
-    final JClassType type = getEnclosedMetaObject().isClassOrInterface();
-    if (type == null) {
-      return null;
+    final List<MetaField> fields = Lists.newArrayList();
+
+    JClassType type = getEnclosedMetaObject().isClass();
+    while (type != null) {
+      for (JField field : type.getFields()) {
+        if (field.isPublic()) {
+          fields.add(new GWTField(oracle, field));
+        }
+      }
+      type = type.getSuperclass();
     }
-    return fromFieldArray(oracle, type.getFields());
+
+    return fields.toArray(new MetaField[fields.size()]);
   }
 
   @Override
   public MetaField[] getDeclaredFields() {
-    return getFields();
+    final List<MetaField> fields = Lists.newArrayList();
+    final JClassType type = getEnclosedMetaObject().isClass();
+
+    if (type != null) {
+      for (JField field : type.getFields()) {
+        fields.add(new GWTField(oracle, field));
+      }
+    }
+
+    return fields.toArray(new MetaField[fields.size()]);
   }
 
   @Override

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/ClassBuilderTest.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/ClassBuilderTest.java
@@ -28,6 +28,7 @@ import org.jboss.errai.codegen.builder.impl.ClassBuilder;
 import org.jboss.errai.codegen.exception.UndefinedMethodException;
 import org.jboss.errai.codegen.meta.MetaClassFactory;
 import org.jboss.errai.codegen.test.model.Baz;
+import org.jboss.errai.codegen.test.model.tree.Parent;
 import org.jboss.errai.codegen.util.Stmt;
 import org.junit.Test;
 
@@ -148,6 +149,21 @@ public class ClassBuilderTest extends AbstractCodegenTest {
         .toJavaString();
 
     assertEquals("failed to generate class with parent", CLASS_WITH_PARENT, cls);
+  }
+
+  @Test
+  public void testDefineClassWithFieldInheritance() {
+    final String cls = ClassBuilder
+        .define("org.foo.Foo", Parent.class)
+        .publicScope()
+        .body()
+        .publicConstructor()
+        .append(Stmt.loadVariable("parentProtected").assignValue(0))
+        .append(Stmt.loadVariable("parentPublic").assignValue(0))
+        .finish()
+        .toJavaString();
+
+    assertEquals("failed to generate class with parent", CLASS_WITH_FIELD_INHERITANCE, cls);
   }
 
   @Test

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/ClassBuilderTestResult.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/ClassBuilderTestResult.java
@@ -76,6 +76,18 @@ public interface ClassBuilderTestResult {
           "   }" +
           " }";
 
+  public static final String CLASS_WITH_FIELD_INHERITANCE =
+      "     package org.foo;" +
+          "" +
+          " import org.jboss.errai.codegen.test.model.tree.Parent;" +
+          "" +
+          " public class Foo extends Parent {" +
+          "   public Foo() {" +
+          "     parentProtected = 0;" +
+          "     parentPublic = 0;" +
+          "   }" +
+          " }";
+
   public static final String ABSTRACT_CLASS =
       "     package org.foo;\n" +
           "\n" +

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/meta/AbstractMetaClassTest.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/meta/AbstractMetaClassTest.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.Lists;
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.codegen.meta.MetaField;
 import org.jboss.errai.codegen.meta.MetaMethod;
@@ -696,6 +697,42 @@ public abstract class AbstractMetaClassTest {
     
 
     assertEquals(expectedMethods.toString(), methodSignatures.toString());
+  }
+
+  @Test
+  public void testGetFields() {
+    final List<String> expectedFields = Lists.newLinkedList();
+    expectedFields.add(Child.class.getCanonicalName() + "." + "childPublic");
+    expectedFields.add(Parent.class.getCanonicalName() + "." + "parentPublic");
+
+    final ArrayList<String> actualFields = new ArrayList<String>();
+    for (MetaField field : getMetaClass(Child.class).getFields()) {
+      actualFields.add(field.getDeclaringClass().getCanonicalName() + "." + field.getName());
+    }
+
+    Collections.sort(expectedFields);
+    Collections.sort(actualFields);
+
+    assertEquals(expectedFields.toString(), actualFields.toString());
+  }
+
+  @Test
+  public void testGetDeclaredFields() {
+    final List<String> expectedFields = Lists.newLinkedList();
+    expectedFields.add(Child.class.getCanonicalName() + "." + "childPrivate");
+    expectedFields.add(Child.class.getCanonicalName() + "." + "childPackage");
+    expectedFields.add(Child.class.getCanonicalName() + "." + "childProtected");
+    expectedFields.add(Child.class.getCanonicalName() + "." + "childPublic");
+
+    final ArrayList<String> actualFields = new ArrayList<String>();
+    for (MetaField field : getMetaClass(Child.class).getDeclaredFields()) {
+      actualFields.add(field.getDeclaringClass().getCanonicalName() + "." + field.getName());
+    }
+
+    Collections.sort(expectedFields);
+    Collections.sort(actualFields);
+
+    assertEquals(expectedFields.toString(), actualFields.toString());
   }
 
 }

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/meta/build/BuildMetaClassTest.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/meta/build/BuildMetaClassTest.java
@@ -1,0 +1,81 @@
+package org.jboss.errai.codegen.test.meta.build;
+
+import com.google.common.collect.Lists;
+import org.jboss.errai.codegen.builder.ClassStructureBuilder;
+import org.jboss.errai.codegen.builder.impl.ClassBuilder;
+import org.jboss.errai.codegen.meta.MetaClass;
+import org.jboss.errai.codegen.meta.MetaField;
+import org.jboss.errai.codegen.test.AbstractCodegenTest;
+import org.jboss.errai.codegen.test.model.tree.Parent;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link org.jboss.errai.codegen.meta.impl.build.BuildMetaClass}.
+ *
+ * Note:
+ * This unit test is not based on {@link org.jboss.errai.codegen.test.meta.AbstractMetaClassTest} because
+ * a {@link org.jboss.errai.codegen.meta.impl.build.BuildMetaClass} cannot be created from an existing
+ * class.
+ *
+ * @author Johannes Barop <jb@barop.de>
+ */
+public class BuildMetaClassTest extends AbstractCodegenTest {
+
+  @Test
+  public void testGetFields() {
+    final ClassStructureBuilder<?> classBuilder = ClassBuilder
+        .define("Child", Parent.class)
+        .publicScope()
+        .body()
+        .privateField("childPrivate", int.class).finish()
+        .packageField("childPackage", int.class).finish()
+        .protectedField("childProtected", int.class).finish()
+        .publicField("childPublic", int.class).finish();
+    final MetaClass child = classBuilder.getClassDefinition();
+    final ArrayList<String> fields = new ArrayList<String>();
+    for (MetaField field : child.getFields()) {
+      fields.add(field.getDeclaringClass().getCanonicalName() + "." + field.getName());
+    }
+
+    final List<String> expectedFields = Lists.newLinkedList();
+    expectedFields.add(child.getCanonicalName() + "." + "childPublic");
+    expectedFields.add(Parent.class.getCanonicalName() + "." + "parentPublic");
+
+    Collections.sort(fields);
+    Collections.sort(expectedFields);
+
+    assertEquals(expectedFields.toString(), fields.toString());
+  }
+
+  @Test
+  public void testGetDeclaredFields() {
+    final ClassStructureBuilder<?> classBuilder = ClassBuilder
+        .define("Child", Parent.class)
+        .publicScope()
+        .body()
+        .privateField("childPrivate", int.class).finish()
+        .packageField("childPackage", int.class).finish()
+        .protectedField("childProtected", int.class).finish()
+        .publicField("childPublic", int.class).finish();
+    final MetaClass child = classBuilder.getClassDefinition();
+    final ArrayList<String> fields = new ArrayList<String>();
+    for (MetaField field : child.getDeclaredFields()) {
+      fields.add(field.getDeclaringClass().getCanonicalName() + "." + field.getName());
+    }
+
+    final List<String> expectedFields = Lists.newLinkedList();
+    expectedFields.add(child.getCanonicalName() + "." + "childPrivate");
+    expectedFields.add(child.getCanonicalName() + "." + "childPackage");
+    expectedFields.add(child.getCanonicalName() + "." + "childProtected");
+    expectedFields.add(child.getCanonicalName() + "." + "childPublic");
+
+    Collections.sort(fields);
+    Collections.sort(expectedFields);
+
+    assertEquals(expectedFields.toString(), fields.toString());
+  }
+}

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/tree/Child.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/tree/Child.java
@@ -7,6 +7,11 @@ package org.jboss.errai.codegen.test.model.tree;
  */
 public class Child extends Parent {
 
+  private int childPrivate;
+  int childPackage;
+  protected int childProtected;
+  public int childPublic;
+
   @Override
   public void interfaceMethodOverriddenMultipleTimes() {}
 

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/tree/Parent.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/tree/Parent.java
@@ -2,6 +2,11 @@ package org.jboss.errai.codegen.test.model.tree;
 
 public class Parent extends Grandparent implements ParentInterface {
 
+  private int parentPrivate;
+  int parentPackage;
+  protected int parentProtected;
+  public int parentPublic;
+
   @Override
   public void interfaceMethodOverriddenMultipleTimes() {}
   


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/ERRAI-640
