### PR TITLE
missing toLowerCase() call + missing  null test on plugin dependency

### DIFF
--- a/errai-cordova-maven-plugin/src/main/groovy/org/jboss/errai/maven/cordova/CordovaMojo.groovy
+++ b/errai-cordova-maven-plugin/src/main/groovy/org/jboss/errai/maven/cordova/CordovaMojo.groovy
@@ -132,11 +132,14 @@ class CordovaMojo extends GroovyMojo {
     }
 
     String getWarSourceDir() {
-        Xpp3Dom config = project.buildPlugins.find{it.key == 'org.apache.maven.plugins:maven-war-plugin'}.configuration
-        if (config) {
-            def found = config.getChildren().find { it.name == 'warSourceDirectory' }
-            if (found) {
-                return found.value
+        def pluginRef = project.buildPlugins.find{it.key == 'org.apache.maven.plugins:maven-war-plugin'}
+        if( pluginRef) {
+            Xpp3Dom config = pluginRef.configuration
+            if (config) {
+                def found = config.getChildren().find { it.name == 'warSourceDirectory' }
+                if (found) {
+                    return found.value
+                }
             }
         }
         return 'src/main/webapp'


### PR DESCRIPTION
While working with this maven plugin on Ubuntu, I ran into a crash due to a missing  toLowerCase() on the $platform variable in updateConfig().

As i was working on a mobile app, independent from the errai framework, i didn't included the  "maven-war-plugin" .
In getWarSourceDir() (line 135) , the process crash if the plugin is missing (it tries to access a property on a null object).
I think the "maven-war-plugin" should not be mandatory in this plugin to let people use this plugin out of the errai framework.
