### PR TITLE
Client CDI classes were not devoted when the package name starts with `c...

### DIFF
--- a/errai-cdi/weld-integration/src/main/java/org/jboss/errai/cdi/server/CDIExtensionPoints.java
+++ b/errai-cdi/weld-integration/src/main/java/org/jboss/errai/cdi/server/CDIExtensionPoints.java
@@ -196,7 +196,7 @@ public class CDIExtensionPoints implements Extension {
     // veto on client side implementations that contain CDI annotations
     // (i.e. @Observes) Otherwise Weld might try to invoke on them
     if (vetoClasses.contains(type.getJavaClass().getName())
-            || (type.getJavaClass().getPackage().getName().matches(".*\\.client(\\..*)?") && !type.getJavaClass()
+            || (type.getJavaClass().getPackage().getName().matches("(^|.*\\.)client(\\..*)?") && !type.getJavaClass()
                     .isInterface())) {
       event.veto();
     }


### PR DESCRIPTION
...lient.`

Follow up of ERRAI-465
