### PR TITLE
Added `-out` parameter to Errai's JUnitShell

### DIFF
--- a/errai-cdi/weld-integration/src/main/java/com/google/gwt/junit/JUnitShell.java
+++ b/errai-cdi/weld-integration/src/main/java/com/google/gwt/junit/JUnitShell.java
@@ -146,6 +146,7 @@ public class JUnitShell extends DevMode {
       // Hard code the server.
       options.setServletContainerLauncher(new MyJettyLauncher());
       // DISABLE: ArgHandlerStartupURLs
+      registerHandler(new com.google.gwt.dev.ArgHandlerOutDirDeprecated(options));
       //registerHandler(new ArgHandlerServer(options));
       registerHandler(new ArgHandlerWarDir(options) {
         @Override


### PR DESCRIPTION
`-out` is a deprecated but valid argument for GWT's JUnitShell. Applications which
use `-out` failed with `Unknown argument: -out` when `errai-weld-integration` is
on the classpath.

For reference: GWT 2.5.1 JUnitShell
https://github.com/gwtproject/gwt/blob/2.5.1/user/src/com/google/gwt/junit/JUnitShell.java#L167
