### PR TITLE
LazySingleton feature + fixes for some complex ioc cases

### DIFF
--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/beanmanager/client/res/SomeLonelEySingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/beanmanager/client/res/SomeLonelEySingleton.java
@@ -1,0 +1,8 @@
+package org.jboss.errai.ioc.async.test.beanmanager.client.res;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class SomeLonelEySingleton {
+
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/beanmanager/client/res/SomeOtherOtherSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/beanmanager/client/res/SomeOtherOtherSingleton.java
@@ -1,0 +1,16 @@
+package org.jboss.errai.ioc.async.test.beanmanager.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+@Singleton
+public class SomeOtherOtherSingleton {
+    
+    
+    public static int instances;
+    
+    @PostConstruct
+    void onPostConstructed() {
+        instances++;
+    }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/beanmanager/client/res/SomeOtherSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/beanmanager/client/res/SomeOtherSingleton.java
@@ -1,0 +1,20 @@
+package org.jboss.errai.ioc.async.test.beanmanager.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+
+@Singleton
+public class SomeOtherSingleton {
+    
+    @Inject
+    private SomeOtherOtherSingleton singleton;
+    
+    public static int instances;
+    
+    @PostConstruct
+    void onPostcontructed() {
+        instances++;
+    }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/beanmanager/client/res/SomeSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/beanmanager/client/res/SomeSingleton.java
@@ -1,0 +1,31 @@
+package org.jboss.errai.ioc.async.test.beanmanager.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+import org.jboss.errai.common.client.util.CreationalCallback;
+import org.jboss.errai.ioc.client.container.IOC;
+import org.jboss.errai.ioc.client.container.async.AsyncBeanManager;
+
+
+// @EntryPoint
+@Singleton
+public class SomeSingleton {
+    
+    public static int instances = 0;
+    
+    @PostConstruct
+    void onPostrConstructed() {
+        instances++;
+        AsyncBeanManager asyncBeanManager = IOC.getAsyncBeanManager();
+        asyncBeanManager.lookupBean(SomeOtherSingleton.class).getInstance(new CreationalCallback<SomeOtherSingleton>() {
+            
+            @Override
+            public void callback(SomeOtherSingleton beanInstance) {
+                // TODO Auto-generated method stub
+                
+            }
+        });
+        
+    }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/constructor/client/AsyncConstructorInjectionTests.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/constructor/client/AsyncConstructorInjectionTests.java
@@ -1,7 +1,5 @@
 package org.jboss.errai.ioc.async.test.constructor.client;
 
-import com.google.gwt.user.client.Timer;
-
 import org.jboss.errai.common.client.util.CreationalCallback;
 import org.jboss.errai.ioc.async.test.constructor.client.res.ConstrInjBean;
 import org.jboss.errai.ioc.client.Container;

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/dependent/client/AsyncDependentScopeIntegrationTest.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/dependent/client/AsyncDependentScopeIntegrationTest.java
@@ -18,6 +18,7 @@ import org.jboss.errai.ioc.async.test.scopes.dependent.client.res.OuterBean;
 import org.jboss.errai.ioc.async.test.scopes.dependent.client.res.ServiceA;
 import org.jboss.errai.ioc.async.test.scopes.dependent.client.res.ServiceB;
 import org.jboss.errai.ioc.async.test.scopes.dependent.client.res.ServiceC;
+import org.jboss.errai.ioc.async.test.scopes.dependent.client.res.SomeOtherSingleton;
 import org.jboss.errai.ioc.async.test.scopes.dependent.client.res.UnreferencedDependentRootBean;
 import org.jboss.errai.ioc.client.Container;
 import org.jboss.errai.ioc.client.IOCClientTestCase;
@@ -40,6 +41,25 @@ public class AsyncDependentScopeIntegrationTest extends IOCClientTestCase {
   public void gwtSetUp() throws Exception {
     DependentBeanCycleB.instanceCount = 1;
     super.gwtSetUp();
+  }
+  
+  public void testComplexSetup() {
+    delayTestFinish(10000);
+
+    Container.runAfterInit(new Runnable() {
+
+      @Override
+      public void run() {
+        IOC.getAsyncBeanManager().lookupBean(SomeOtherSingleton.class)
+                .getInstance(new CreationalCallback<SomeOtherSingleton>() {
+
+                  @Override
+                  public void callback(SomeOtherSingleton beanInstance) {
+                    finishTest();
+                  }
+                });
+      }
+    });
   }
 
   public void testDependentBeanScope() {

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/dependent/client/res/SomeDependendBeanWithSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/dependent/client/res/SomeDependendBeanWithSingleton.java
@@ -1,0 +1,22 @@
+package org.jboss.errai.ioc.async.test.scopes.dependent.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+@Dependent
+public class SomeDependendBeanWithSingleton {
+  private int instances;
+  @Inject
+  private SomeSingleton someSingleton;
+
+  @PostConstruct
+  void post() {
+    assert (getInstances() < someSingleton.getInstances()) : "SomeSIngleton must be created before dependend bean "+getInstances() + " + "+someSingleton.getInstances();
+    instances++;
+  }
+
+  public int getInstances() {
+    return instances;
+  }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/dependent/client/res/SomeOtherSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/dependent/client/res/SomeOtherSingleton.java
@@ -1,0 +1,43 @@
+package org.jboss.errai.ioc.async.test.scopes.dependent.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Singleton;
+
+import org.jboss.errai.common.client.util.CreationalCallback;
+import org.jboss.errai.ioc.client.Container;
+import org.jboss.errai.ioc.client.container.IOC;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.Timer;
+
+@Singleton
+public class SomeOtherSingleton {
+
+  @PostConstruct
+  void onPost() {
+    Container.runAfterInit(new Runnable() {
+
+      @Override
+      public void run() {
+        onContainerInit();
+      }
+    });
+  }
+
+  protected void onContainerInit() {
+    IOC.getAsyncBeanManager()
+            .lookupBean(SomeDependendBeanWithSingleton.class)
+            .getInstance(
+                    new CreationalCallback<SomeDependendBeanWithSingleton>() {
+
+                      @Override
+                      public void callback(
+                              SomeDependendBeanWithSingleton beanInstance) {
+                        // TODO Auto-generated method stub
+
+                      }
+                    });
+
+  }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/dependent/client/res/SomeSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/dependent/client/res/SomeSingleton.java
@@ -1,0 +1,19 @@
+package org.jboss.errai.ioc.async.test.scopes.dependent.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+@Singleton
+public class SomeSingleton {
+  private  int instances;
+
+  @PostConstruct
+  void postConstruct() {
+    instances++;
+  }
+
+  public int getInstances() {
+    return instances;
+  }
+
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/AsyncLazySingletonScopeTests.gwt.xml
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/AsyncLazySingletonScopeTests.gwt.xml
@@ -1,0 +1,10 @@
+<module>
+    <inherits name='com.google.gwt.user.User'/>
+    <inherits name="com.google.gwt.junit.JUnit"/>
+    <inherits name="org.jboss.errai.ioc.Container"/>
+    <inherits name="javax.enterprise.Support" />
+    <inherits name="org.jboss.errai.bus.ErraiBus"/>
+    <inherits name="com.google.gwt.logging.Logging"/>
+
+    <set-property name='gwt.logging.logLevel' value='SEVERE'/>
+</module>

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/AsyncLazySingletonScopeBasicTests.gwt.xml
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/AsyncLazySingletonScopeBasicTests.gwt.xml
@@ -1,0 +1,10 @@
+<module>
+    <inherits name='com.google.gwt.user.User'/>
+    <inherits name="com.google.gwt.junit.JUnit"/>
+    <inherits name="org.jboss.errai.ioc.Container"/>
+    <inherits name="javax.enterprise.Support" />
+    <inherits name="org.jboss.errai.bus.ErraiBus"/>
+    <inherits name="com.google.gwt.logging.Logging"/>
+
+    <set-property name='gwt.logging.logLevel' value='SEVERE'/>
+</module>

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/AsyncLazySingletonScopeIntegrationTest.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/AsyncLazySingletonScopeIntegrationTest.java
@@ -1,0 +1,229 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client;
+
+import org.jboss.errai.common.client.util.CreationalCallback;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res.DependendBeanWithSingleton;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res.LazySingletonBean;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res.SingletonBean;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res.SomeLonelEySingleton;
+import org.jboss.errai.ioc.client.Container;
+import org.jboss.errai.ioc.client.IOCClientTestCase;
+import org.jboss.errai.ioc.client.container.IOC;
+
+import com.google.gwt.user.client.Timer;
+
+/**
+ * @author mariusgerwinn
+ */
+public class AsyncLazySingletonScopeIntegrationTest extends IOCClientTestCase {
+
+  private static Object singletonInstance;
+  private static Object lazySingletonInstance;
+
+  @Override
+  public String getModuleName() {
+    return "org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.AsyncLazySingletonScopeBasicTests";
+  }
+
+  @Override
+  protected void gwtTearDown() throws Exception {
+    super.gwtTearDown();
+    org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res.LazySingletonBean.instances = 0;
+    SingletonBean.instances = 0;
+  }
+  
+  public void testLazySingletonPostConstructWithBeanManager() {
+    delayTestFinish(10000);
+    Container.runAfterInit(new Runnable() {
+        
+        @Override
+        public void run() {
+            IOC.getAsyncBeanManager().lookupBean(LazySingletonBean.class).getInstance(new CreationalCallback<LazySingletonBean>() {
+                
+                @Override
+                public void callback(LazySingletonBean beanInstance) {
+                    beanInstance.doSomeTHing();
+                    finishTest();
+                }
+            });
+        }
+    });
+}
+  private static int called;
+  private static int called2;
+  public void testRunAfteriNitWorks() {
+    delayTestFinish(10000);
+    Container.runAfterInit(new Runnable() {
+      public void run() {
+        assertTrue(called==0);
+        called++;
+        // waint since run after init usaly fails async a few miliseconds after
+        // runnable has been called
+        new Timer() {
+          @Override
+          public void run() {
+            finishTest();
+
+          }
+        }.schedule(1000);
+      };
+    });
+  }
+  public void testRunAfteriNitWorks2() {
+    delayTestFinish(10000);
+    Container.runAfterInit(new Runnable() {
+      public void run() {
+        assertTrue(called2==0);
+        called2++;
+        // waint since run after init usaly fails async a few miliseconds after
+        // runnable has been called
+        new Timer() {
+          @Override
+          public void run() {
+            finishTest();
+            
+          }
+        }.schedule(1000);
+      };
+    });
+  }
+
+  public void testLazySingletonNotCreatedByContainer() {
+    delayTestFinish(10000);
+    Container.runAfterInit(new Runnable() {
+      @Override
+      public void run() {
+        
+        new Timer() {
+
+          @Override
+          public void run() {
+            assertSame(
+                    "Lazy Singleton is already created by the container",
+                    0,
+                    org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res.LazySingletonBean.instances);
+            assertSame("Singleton is not created", 1, SingletonBean.instances);
+
+            finishTest();
+
+          }
+        }.schedule(1000);
+      }
+    });
+  }
+
+  private void singletonSetup() {
+    Container.runAfterInit(new Runnable() {
+      @Override
+      public void run() {
+        IOC.getAsyncBeanManager().lookupBean(SomeLonelEySingleton.class)
+                .getInstance(new CreationalCallback<SomeLonelEySingleton>() {
+
+                  @Override
+                  public void callback(SomeLonelEySingleton beanInstance) {
+                    // since order in tests is not guranteed we need to run this
+                    // test twice. first time it will be null
+                    if (singletonInstance == null)
+                      singletonInstance = beanInstance;
+                    else
+                      assertNotSame(singletonInstance, beanInstance);
+                    finishTest();
+                  }
+                });
+      }
+    });
+  }
+
+  public void testSingletonDiffersInEachSetup() {
+    delayTestFinish(60000);
+    // since order in tests is not guranteed we need to run this test twice.
+    // first time it will be null
+    singletonSetup();
+  }
+
+  public void testSingletonDiffersInEachSetup2() {
+    delayTestFinish(60000);
+    // since order in tests is not guranteed we need to run this test twice.
+    // first time it will be null
+    singletonSetup();
+  }
+  
+  
+  private void lazySingletonSetup() {
+    Container.runAfterInit(new Runnable() {
+      @Override
+      public void run() {
+        IOC.getAsyncBeanManager().lookupBean(LazySingletonBean.class)
+                .getInstance(new CreationalCallback<LazySingletonBean>() {
+
+                  @Override
+                  public void callback(LazySingletonBean beanInstance) {
+                    // since order in tests is not guranteed we need to run this
+                    // test twice. first time it will be null
+                    if (lazySingletonInstance == null)
+                      lazySingletonInstance = beanInstance;
+                    else
+                      assertNotSame(lazySingletonInstance, beanInstance);
+                    
+                    beanInstance.doSomeTHing();
+                    finishTest();
+                  }
+                });
+      }
+    });
+  }
+
+  public void testLazySingletonDiffersInEachSetup() {
+    delayTestFinish(60000);
+    // since order in tests is not guranteed we need to run this test twice.
+    // first time it will be null
+    lazySingletonSetup();
+  }
+
+  public void testLazySingletonDiffersInEachSetup2() {
+    delayTestFinish(60000);
+    // since order in tests is not guranteed we need to run this test twice.
+    // first time it will be null
+    lazySingletonSetup();
+  }
+
+  public void testBeanManagerAndNormalInjectedIsTheSameInstance() {
+    delayTestFinish(60000);
+    Container.runAfterInit(new Runnable() {
+      @Override
+      public void run() {
+        IOC.getAsyncBeanManager()
+                .lookupBean(DependendBeanWithSingleton.class)
+                .getInstance(
+                        new CreationalCallback<DependendBeanWithSingleton>() {
+                          private LazySingletonBean singletonBeanInjected;
+
+                          @Override
+                          public void callback(
+                                  final DependendBeanWithSingleton provider) {
+                            assertNotNull(provider.getBean());
+                            singletonBeanInjected = provider.getBean();
+                            singletonBeanInjected.doSomeTHing();
+
+                            IOC.getAsyncBeanManager()
+                                    .lookupBean(LazySingletonBean.class)
+                                    .getInstance(
+                                            new CreationalCallback<LazySingletonBean>() {
+                                              @Override
+                                              public void callback(
+                                                      final LazySingletonBean bean) {
+                                                assertNotNull(bean);
+                                                assertSame(
+                                                        "A values are not the same instances",
+                                                        singletonBeanInjected,
+                                                        bean);
+                                                bean.doSomeTHing();
+                                                finishTest();
+                                              }
+                                            });
+                          }
+                        });
+      }
+    });
+  }
+
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/res/DependendBeanWithSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/res/DependendBeanWithSingleton.java
@@ -1,0 +1,25 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+
+@Dependent
+public class DependendBeanWithSingleton {
+    
+    @Inject
+    private
+    SingletonBean bean2;
+    
+    @Inject
+    private
+    LazySingletonBean bean;
+
+    public SingletonBean getBean2() {
+      return bean2;
+    }
+
+    public LazySingletonBean getBean() {
+      return bean;
+    }    
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/res/LazySingletonBean.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/res/LazySingletonBean.java
@@ -1,0 +1,34 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.errai.ioc.client.LazySingleton;
+import org.jboss.errai.ioc.client.api.LoadAsync;
+
+import com.google.common.base.Preconditions;
+
+@Singleton
+@LazySingleton
+@LoadAsync
+public class LazySingletonBean {
+
+  public static int instances;
+
+  @Inject
+  private SingletonBean singleton;
+
+  private boolean postConstructed;
+  @PostConstruct
+  private void postConstr() {
+    if(postConstructed)throw new IllegalArgumentException("already postconstructed");
+    postConstructed=true;
+    assert (SingletonBean.instances > instances) : "Singletonbean must be called before calling postConstruct";
+    instances++;
+  }
+  
+  public void doSomeTHing() {
+    if(!postConstructed)throw new IllegalArgumentException("postConstruct not called yet");
+  }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/res/SingletonBean.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/res/SingletonBean.java
@@ -1,0 +1,17 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+@Singleton
+public class SingletonBean {
+  public static int instances;
+
+  private boolean postConstructed;
+  @PostConstruct
+  void onPostConstruct() {
+    if(postConstructed)throw new IllegalArgumentException("already postconstructed");
+    postConstructed=true;
+    instances++;
+  }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/res/SomeLonelEySingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/basicTest/client/res/SomeLonelEySingleton.java
@@ -1,0 +1,8 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.basicTest.client.res;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class SomeLonelEySingleton {
+
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/AsyncLazySingletonScopeIntegrationTest.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/AsyncLazySingletonScopeIntegrationTest.java
@@ -1,0 +1,334 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client;
+
+import org.jboss.errai.common.client.util.CreationalCallback;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.DependenBeanWithProvidedBean;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.DependendBean2WithSingleton;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.DependendBeanWithSingleton;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.LazySingletonTestUtil;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.MyLazyBeanInterface;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.ProvidedBean;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.SomeDependendBeanThatLoadsLazySIngletobBeanWithBeanManager;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.SomeLazySingletonBeanForBeanManager;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.SomeSingletonBean;
+import org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.SomeSingletonBeanThatLoadsLazySIngletobBeanWithBeanManager;
+import org.jboss.errai.ioc.client.Container;
+import org.jboss.errai.ioc.client.IOCClientTestCase;
+import org.jboss.errai.ioc.client.container.IOC;
+
+import com.google.gwt.user.client.Timer;
+
+public class AsyncLazySingletonScopeIntegrationTest extends IOCClientTestCase {
+
+  @Override
+  public String getModuleName() {
+    return "org.jboss.errai.ioc.async.test.scopes.lazySingleton.AsyncLazySingletonScopeTests";
+  }
+
+  @Override
+  protected void gwtTearDown() throws Exception {
+    SomeSingletonBeanThatLoadsLazySIngletobBeanWithBeanManager.instances = 0;
+    SomeSingletonBean.instances = 0;
+    SomeLazySingletonBeanForBeanManager.instances = 0;
+    super.gwtTearDown();
+  }
+
+  public void testRunAfteriNitWorks() {
+    delayTestFinish(10000);
+    Container.runAfterInit(new Runnable() {
+      public void run() {
+        // waint since run after init usaly fails async a few miliseconds after
+        // runnable has been called
+        new Timer() {
+          @Override
+          public void run() {
+            IOC.getAsyncBeanManager()
+                    .lookupBean(SomeLazySingletonBeanForBeanManager.class)
+                    .getInstance(
+                            new CreationalCallback<SomeLazySingletonBeanForBeanManager>() {
+
+                              @Override
+                              public void callback(
+                                      SomeLazySingletonBeanForBeanManager beanInstance) {
+                                new Timer() {
+                                  @Override
+                                  public void run() {
+                                    finishTest();
+                                  }
+                                }.schedule(1000);
+                              }
+                            });
+
+          }
+        }.schedule(1000);
+      };
+    });
+  }
+
+  public void testLazySingletonNotCreatedByContainer() {
+    delayTestFinish(10000);
+    Container.runAfterInit(new Runnable() {
+      @Override
+      public void run() {
+        assertFalse(
+                "Lazy Singleton is already created by the container",
+                LazySingletonTestUtil
+                        .getOrderOfCreation()
+                        .contains(
+
+                                "org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res.LazySingletonBean"));
+        finishTest();
+      }
+    });
+  }
+
+  public void testSameInstanceOfLazyNonLazySingletonRetrievedDueToInjection() {
+    delayTestFinish(15000);
+
+    Container.runAfterInit(new Runnable() {
+      DependendBeanWithSingleton dependendBean1;
+
+      DependendBeanWithSingleton dependendBean2;
+
+      DependendBean2WithSingleton dependendBean21;
+
+      DependendBean2WithSingleton dependendBean22;
+
+      @Override
+      public void run() {
+        IOC.getAsyncBeanManager()
+                .lookupBean(DependendBeanWithSingleton.class)
+                .getInstance(
+                        new CreationalCallback<DependendBeanWithSingleton>() {
+                          @Override
+                          public void callback(
+                                  final DependendBeanWithSingleton dependendBeanWithSingleton) {
+                            dependendBean1 = dependendBeanWithSingleton;
+
+                            IOC.getAsyncBeanManager()
+                                    .lookupBean(
+                                            DependendBeanWithSingleton.class)
+                                    .getInstance(
+                                            new CreationalCallback<DependendBeanWithSingleton>() {
+                                              @Override
+                                              public void callback(
+                                                      final DependendBeanWithSingleton provider) {
+                                                dependendBean2 = provider;
+                                                assertNotSame(
+                                                        "DependendBeanWithSingleton are the same",
+                                                        dependendBean1,
+                                                        dependendBean2);
+                                                assertSame(
+                                                        "A values are not the same instances",
+                                                        dependendBean1
+                                                                .getLazySingletonBean(),
+                                                        dependendBean2
+                                                                .getLazySingletonBean());
+                                                assertSame(
+                                                        "Singleton retrieved instances are not the same ",
+                                                        dependendBean1
+                                                                .getBean2(),
+                                                        dependendBean2
+                                                                .getBean2());
+
+                                                IOC.getAsyncBeanManager()
+                                                        .lookupBean(
+                                                                DependendBean2WithSingleton.class)
+                                                        .getInstance(
+                                                                new CreationalCallback<DependendBean2WithSingleton>() {
+                                                                  @Override
+                                                                  public void callback(
+                                                                          final DependendBean2WithSingleton provider) {
+                                                                    dependendBean21 = provider;
+
+                                                                    IOC.getAsyncBeanManager()
+                                                                            .lookupBean(
+                                                                                    DependendBean2WithSingleton.class)
+                                                                            .getInstance(
+                                                                                    new CreationalCallback<DependendBean2WithSingleton>() {
+                                                                                      @Override
+                                                                                      public void callback(
+                                                                                              final DependendBean2WithSingleton provider) {
+                                                                                        dependendBean22 = provider;
+                                                                                        assertNotSame(
+                                                                                                "DependendBeanWithSingleton are the same",
+                                                                                                dependendBean21,
+                                                                                                dependendBean22);
+                                                                                        assertSame(
+                                                                                                "Values are not the same instances",
+                                                                                                dependendBean21
+                                                                                                        .getLazySingletonBean(),
+                                                                                                dependendBean22
+                                                                                                        .getLazySingletonBean());
+                                                                                        assertSame(
+                                                                                                "Values are not the same instances",
+                                                                                                dependendBean1
+                                                                                                        .getLazySingletonBean(),
+                                                                                                dependendBean21
+                                                                                                        .getLazySingletonBean());
+                                                                                        finishTest();
+                                                                                      }
+                                                                                    });
+                                                                  }
+                                                                });
+                                              }
+                                            });
+                          }
+                        });
+
+      }
+    });
+
+  }
+
+  public void testGettingBeanWithManager() {
+    delayTestFinish(10000);
+
+    Container.runAfterInit(new Runnable() {
+      MyLazyBeanInterface myLazySingletonBean1;
+
+      MyLazyBeanInterface myLazySingletonBean2;
+
+      @Override
+      public void run() {
+        new Timer() {
+          @Override
+          public void run() {
+            IOC.getAsyncBeanManager().lookupBean(MyLazyBeanInterface.class)
+                    .getInstance(new CreationalCallback<MyLazyBeanInterface>() {
+                      @Override
+                      public void callback(final MyLazyBeanInterface provider) {
+                        myLazySingletonBean1 = provider;
+                        assertNotNull(provider);
+                      }
+                    });
+          }
+        }.schedule(1500);
+
+        new Timer() {
+          @Override
+          public void run() {
+            IOC.getAsyncBeanManager().lookupBean(MyLazyBeanInterface.class)
+                    .getInstance(new CreationalCallback<MyLazyBeanInterface>() {
+                      @Override
+                      public void callback(final MyLazyBeanInterface provider) {
+                        myLazySingletonBean2 = provider;
+                        assertNotNull(provider);
+                        assertSame("A values are not the same instances",
+                                myLazySingletonBean1, myLazySingletonBean2);
+                        finishTest();
+                      }
+                    });
+          }
+        }.schedule(1500);
+      }
+    });
+
+  }
+
+  public void testProvidedBean() {
+    delayTestFinish(10000);
+
+    Container.runAfterInit(new Runnable() {
+      ProvidedBean providedBean1;
+
+      ProvidedBean providedBean2;
+
+      @Override
+      public void run() {
+        IOC.getAsyncBeanManager()
+                .lookupBean(DependenBeanWithProvidedBean.class)
+                .getInstance(
+                        new CreationalCallback<DependenBeanWithProvidedBean>() {
+                          @Override
+                          public void callback(
+                                  final DependenBeanWithProvidedBean provider) {
+                            assertNotNull(provider.getBean());
+                            finishTest();
+                          }
+                        });
+      }
+    });
+  }
+
+  public void testPostConstructOrder() {
+    delayTestFinish(20000);
+    Container.$(new Runnable() {
+
+      @Override
+      public void run() {
+        assertSame(1, SomeSingletonBean.instances);
+        assertSame(
+                1,
+                SomeSingletonBeanThatLoadsLazySIngletobBeanWithBeanManager.instances);
+        finishTest();
+      }
+    });
+  }
+
+  
+  public void testGettingDependedBeanWithLazySingletonBean() {
+    delayTestFinish(20000);
+    Container.$(new Runnable() {
+
+      @Override
+      public void run() {
+       IOC.getAsyncBeanManager().lookupBean(SomeDependendBeanThatLoadsLazySIngletobBeanWithBeanManager.class).getInstance(new CreationalCallback<SomeDependendBeanThatLoadsLazySIngletobBeanWithBeanManager>() {
+        
+        @Override
+        public void callback(
+                SomeDependendBeanThatLoadsLazySIngletobBeanWithBeanManager beanInstance) {
+          new Timer() {
+            
+            @Override
+            public void run() {
+              finishTest();
+            }
+          }.schedule(500);
+        }
+      });
+      }
+    });
+  }
+  public void testBeanManagerAndNormalInjectedIsTheSameInstance() {
+    delayTestFinish(60000);
+
+    Container.runAfterInit(new Runnable() {
+      @Override
+      public void run() {
+        IOC.getAsyncBeanManager()
+                .lookupBean(DependendBeanWithSingleton.class)
+                .getInstance(
+                        new CreationalCallback<DependendBeanWithSingleton>() {
+                          private MyLazyBeanInterface singletonBeanInjected;
+
+                          private MyLazyBeanInterface singletonBeanRetrievedByBeanManager;
+
+                          @Override
+                          public void callback(
+                                  final DependendBeanWithSingleton provider) {
+                            assertNotNull(provider.getLazySingletonBean());
+                            singletonBeanInjected = provider
+                                    .getLazySingletonBean();
+
+                            IOC.getAsyncBeanManager()
+                                    .lookupBean(MyLazyBeanInterface.class)
+                                    .getInstance(
+                                            new CreationalCallback<MyLazyBeanInterface>() {
+                                              @Override
+                                              public void callback(
+                                                      final MyLazyBeanInterface provider) {
+                                                assertNotNull(provider);
+                                                singletonBeanRetrievedByBeanManager = provider;
+                                                assertSame(
+                                                        "A values are not the same instances",
+                                                        singletonBeanInjected,
+                                                        singletonBeanRetrievedByBeanManager);
+                                                finishTest();
+                                              }
+                                            });
+                          }
+                        });
+      }
+    });
+  }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/DependenBeanWithProvidedBean.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/DependenBeanWithProvidedBean.java
@@ -1,0 +1,19 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+
+@Dependent
+public class DependenBeanWithProvidedBean {
+    
+    
+    @Inject
+    ProvidedBean bean;
+    
+  
+    public ProvidedBean getBean() {
+        return bean;
+    }
+    
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/DependendBean.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/DependendBean.java
@@ -1,0 +1,8 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class DependendBean {
+    
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/DependendBean2WithSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/DependendBean2WithSingleton.java
@@ -1,0 +1,18 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+
+@Dependent
+public class DependendBean2WithSingleton {
+    
+    
+    @Inject
+    MyLazyBeanInterface bean;
+    
+    public MyLazyBeanInterface getLazySingletonBean() {
+        return bean;
+    }
+
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/DependendBeanWithSingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/DependendBeanWithSingleton.java
@@ -1,0 +1,25 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+
+@Dependent
+public class DependendBeanWithSingleton {
+    
+    @Inject
+    SingletonBean bean2;
+    
+    @Inject
+    MyLazyBeanInterface bean;
+   
+    public MyLazyBeanInterface getLazySingletonBean() {
+        return bean;
+    }
+    
+ 
+    public SingletonBean getBean2() {
+        return bean2;
+    } 
+    
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/LazySingletonBean.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/LazySingletonBean.java
@@ -1,0 +1,20 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+import org.jboss.errai.ioc.client.LazySingleton;
+import org.jboss.errai.ioc.client.api.LoadAsync;
+
+@Singleton
+@LazySingleton
+@LoadAsync
+public class LazySingletonBean implements MyLazyBeanInterface {
+    
+    
+    @PostConstruct
+    private void postConstr() {
+        LazySingletonTestUtil.record(LazySingletonBean.class.getName());
+    }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/LazySingletonTestUtil.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/LazySingletonTestUtil.java
@@ -1,0 +1,23 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class LazySingletonTestUtil {
+    private static final List<String> order = new ArrayList<String>();
+    
+    public static void reset() {
+        order.clear();
+    }
+    
+    public static void record(final String fired) {
+        order.add(fired);
+    }
+    
+    public static List<String> getOrderOfCreation() {
+        return Collections.unmodifiableList(order);
+    }
+    
+    
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/MyLazyBeanInterface.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/MyLazyBeanInterface.java
@@ -1,0 +1,6 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+
+public interface MyLazyBeanInterface {
+    
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/ProvidedBean.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/ProvidedBean.java
@@ -1,0 +1,15 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+
+import javax.annotation.PostConstruct;
+
+
+public abstract class ProvidedBean {
+    
+    
+    
+    @PostConstruct
+    void onPostruct() {
+        LazySingletonTestUtil.record(ProvidedBean.class.getName());
+    }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/ProvidedBeanProvider.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/ProvidedBeanProvider.java
@@ -1,0 +1,19 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.jboss.errai.ioc.client.api.IOCProvider;
+
+@Singleton
+@IOCProvider
+public class ProvidedBeanProvider implements Provider<ProvidedBean> {
+    
+    
+    @Override
+    public ProvidedBean get() {
+        return new ProvidedBean() {};
+    }
+    
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SimpleLazySingleton.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SimpleLazySingleton.java
@@ -1,0 +1,12 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.inject.Singleton;
+
+import org.jboss.errai.ioc.client.LazySingleton;
+
+
+@Singleton
+@LazySingleton
+public class SimpleLazySingleton {
+
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SingletonBean.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SingletonBean.java
@@ -1,0 +1,14 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+@Singleton
+public class SingletonBean {
+    
+    @PostConstruct
+    private void postConstr() {
+        LazySingletonTestUtil.record(SingletonBean.class.getName());
+    }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SomeDependendBeanThatLoadsLazySIngletobBeanWithBeanManager.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SomeDependendBeanThatLoadsLazySIngletobBeanWithBeanManager.java
@@ -1,0 +1,41 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Singleton;
+
+import org.jboss.errai.common.client.util.CreationalCallback;
+import org.jboss.errai.ioc.client.container.IOC;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.user.client.Timer;
+
+@Dependent
+public class SomeDependendBeanThatLoadsLazySIngletobBeanWithBeanManager {
+
+  public static int instances;
+
+  @PostConstruct
+  void onPostConstruct() {
+    instances++;
+    Scheduler.get().scheduleDeferred(new ScheduledCommand() {
+      
+      @Override
+      public void execute() {
+        IOC.getAsyncBeanManager()
+        .lookupBean(SomeLazySingletonBeanForBeanManager.class)
+        .getInstance(
+                new CreationalCallback<SomeLazySingletonBeanForBeanManager>() {
+                  
+                  @Override
+                  public void callback(
+                          SomeLazySingletonBeanForBeanManager beanInstance) {
+                    // TODO Auto-generated method stub
+                    
+                  }
+                });
+      }
+    });
+  }
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SomeLazySingletonBeanForBeanManager.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SomeLazySingletonBeanForBeanManager.java
@@ -1,0 +1,28 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.errai.common.client.api.Assert;
+import org.jboss.errai.ioc.client.LazySingleton;
+
+import com.google.common.base.Preconditions;
+
+
+@LazySingleton
+@Singleton
+public class SomeLazySingletonBeanForBeanManager {
+
+  public static int instances;
+  @Inject
+  private SomeSingletonBean bean;
+  
+  @PostConstruct
+  void onPostconstruct(){
+    assert(SomeSingletonBean.instances>instances) : "SomeSingletonBean must be created before this lazy singleton bean";
+    instances++;
+  }
+  
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SomeSingletonBean.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SomeSingletonBean.java
@@ -1,0 +1,20 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+@Singleton
+public class SomeSingletonBean {
+
+  public static int instances;
+  
+  private boolean postCOnstructed = false;
+  
+  @PostConstruct
+  void onPostConstructed(){
+    if(postCOnstructed)throw new IllegalStateException("already postconstructed");
+    postCOnstructed=true;
+    instances++;
+  }
+  
+}

--- a/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SomeSingletonBeanThatLoadsLazySIngletobBeanWithBeanManager.java
+++ b/errai-ioc-async-tests/src/test/java/org/jboss/errai/ioc/async/test/scopes/lazySingleton/client/res/SomeSingletonBeanThatLoadsLazySIngletobBeanWithBeanManager.java
@@ -1,0 +1,43 @@
+package org.jboss.errai.ioc.async.test.scopes.lazySingleton.client.res;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+import org.jboss.errai.common.client.util.CreationalCallback;
+import org.jboss.errai.ioc.client.Container;
+import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.ioc.client.container.IOC;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.user.client.Timer;
+
+@EntryPoint
+public class SomeSingletonBeanThatLoadsLazySIngletobBeanWithBeanManager implements Runnable {
+
+  public static int instances;
+
+  @PostConstruct
+  void onPostConstruct() {
+    instances++;
+    //calling bean manager directly causes error in test right now. so thats a workaround
+     Container.$(this);
+  }
+
+  @Override
+  public void run() {
+    IOC.getAsyncBeanManager()
+    .lookupBean(SomeLazySingletonBeanForBeanManager.class)
+    .getInstance(
+            new CreationalCallback<SomeLazySingletonBeanForBeanManager>() {
+
+              @Override
+              public void callback(
+                      SomeLazySingletonBeanForBeanManager beanInstance) {
+                // TODO Auto-generated method stub
+
+              }
+            });
+    
+  }
+}

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/Container.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/Container.java
@@ -127,6 +127,7 @@ public class Container implements EntryPoint {
   public static void runAfterInit(final Runnable runnable) {
     if (init) {
       runnable.run();
+      return;
     }
 
     afterInit.add(runnable);

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/LazySingleton.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/LazySingleton.java
@@ -1,0 +1,23 @@
+package org.jboss.errai.ioc.client;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+
+/**
+* When used in addition to {@link javax.inject.Singleton}  to force the lazy instantiation of the singleton.
+* </br>
+* <strong>NOTE:</strong> Requires AsyncBeanManager
+*
+*/
+@Retention(RUNTIME)
+@Target({TYPE,ElementType.METHOD})
+@Documented
+public @interface LazySingleton {
+    
+}

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/AsyncBeanManagerSetup.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/AsyncBeanManagerSetup.java
@@ -43,4 +43,14 @@ public interface AsyncBeanManagerSetup {
                String name,
                boolean concreteType,
                Class<Object> beanActivatorType);
+                            
+  void addBean(Class<Object> type,
+               Class<?> beanType,
+               AsyncBeanProvider<Object> callback,
+               AsyncCreationalContext context,
+               AsyncInjectionContext injectionContext,
+               Annotation[] qualifiers,
+               String name,
+               boolean concreteType,
+               Class<Object> beanActivatorType);
 }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/AsyncCreationalContext.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/AsyncCreationalContext.java
@@ -60,8 +60,9 @@ public class AsyncCreationalContext extends AbstractCreationalContext {
 
       if (!beanList.isEmpty()) {
         final AsyncBeanDef<T> bean = beanList.iterator().next();
-        if (bean != null && bean instanceof AsyncSingletonBean) {
-          //   addWait(new BeanRef(beanType, qualifiers), creationalCallback);
+        //return instance directly if asyncsingleton bean. just check if it is not the first call for that singleton bean (isready will be false)
+        if (bean != null && bean instanceof AsyncSingletonBean && ((AsyncSingletonBean)bean).isReady()) {
+          //   addWait(new BeanRef(beanType, qualifiers), creationa8lCallback);
           bean.getInstance(creationalCallback);
           return;
         }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/AsyncInjectionContext.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/AsyncInjectionContext.java
@@ -63,31 +63,60 @@ public class AsyncInjectionContext implements BootstrapInjectionContext {
     addBean(type, beanType, provider, singleton, qualifiers, name, concrete, null);   
   }
 
-  public void addBean(final Class type,
-      final Class beanType,
-      final AsyncBeanProvider provider,
-      final boolean singleton,
-      final Annotation[] qualifiers,
-      final String name,
-      final boolean concrete,
-      final Class beanActivatorType) {
+   public void addBean(final Class type,
+  					  final Class beanType,
+          			  final AsyncBeanProvider provider,
+          			  final boolean singleton,
+          			  final boolean lazySingleton,
+          			  final Annotation[] qualifiers,
+          			  final String name,
+          			  final boolean concrete) {
 
+    addBean(type, beanType, provider, singleton, lazySingleton, qualifiers, name, concrete, null);
+  }
+
+  public void addBean(final Class type,
+  					  final Class beanType,
+          			  final AsyncBeanProvider provider,
+          			  final boolean singleton,
+          			  final Annotation[] qualifiers,
+          			  final String name,
+          			  final boolean concrete,
+          			  final Class beanActivatorType) {
+    addBean(type, beanType, provider, singleton, false, qualifiers, name, concrete, null);
+  }
+
+  public void addBean(final Class type,
+  					  final Class beanType,
+          			  final AsyncBeanProvider provider,
+          			  final boolean singleton,
+          			  final boolean lazySingleton, 
+         			  final Annotation[] qualifiers,
+          			  final String name, 
+         			  final boolean concrete,
+          			  final Class beanActivatorType) {
     if (singleton) {
       final CreationalCallback creationalCallback = new CreationalCallback() {
         @Override
         public void callback(final Object beanInstance) {
-          }
+        }
 
         @Override
         public String toString() {
           return type.getName();
         }
       };
-      context.getSingletonInstanceOrNew(this, provider, creationalCallback, type, beanType, qualifiers, name);
+      if (!lazySingleton) {
+        // Creating singleton instance: " + type);
+        context.getSingletonInstanceOrNew(this, provider, creationalCallback, type, beanType, qualifiers, name);
+      }
+      else {
+        // Lazy singleton detected skip creating instance: " + type);
+        ((AsyncBeanManagerSetup) manager).addBean(type, beanType, provider, context, this, qualifiers, name, concrete, beanActivatorType);
+      }
     }
     else {
-      ((AsyncBeanManagerSetup) manager).addBean(type, beanType, provider, null, qualifiers, name, concrete,
-          beanActivatorType);
+      ((AsyncBeanManagerSetup) manager).addBean(type, beanType, provider, null, qualifiers, name, concrete, beanActivatorType);
     }
 
   }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/AsyncSingletonBean.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/AsyncSingletonBean.java
@@ -3,6 +3,7 @@ package org.jboss.errai.ioc.client.container.async;
 import java.lang.annotation.Annotation;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 
 import org.jboss.errai.common.client.util.CreationalCallback;
 
@@ -11,7 +12,8 @@ import org.jboss.errai.common.client.util.CreationalCallback;
  */
 public class AsyncSingletonBean<T> extends AsyncDependentBean<T> {
   private final T instance;
-
+  private final AsyncInjectionContext injectionContext;
+  
   private AsyncSingletonBean(final AsyncBeanManagerImpl beanManager,
                            final Class<T> type,
                            final Class<?> beanType,
@@ -23,9 +25,28 @@ public class AsyncSingletonBean<T> extends AsyncDependentBean<T> {
                            final Class<Object> beanActivatorType) {
 
     super(beanManager, type, beanType, qualifiers, name, concrete, callback, beanActivatorType);
+    // normal singleton
     this.instance = instance;
+    this.injectionContext = null;
+    getOrCreateSingletonBeanProvider();
   }
-
+  
+  private AsyncSingletonBean(final AsyncBeanManagerImpl beanManager,
+  							 final Class<T> type,
+        				 	 final Class<?> beanType,
+        				 	 final Annotation[] qualifiers,
+        				 	 final String name,
+          					 final boolean concrete,
+          					 final AsyncBeanProvider<T> callback,
+          					 final AsyncCreationalContext context,
+         					 final AsyncInjectionContext injectionContext,
+         					 final Class<Object> beanActivatorType) {
+    super(beanManager, type, beanType, qualifiers, name, concrete, callback, beanActivatorType);
+    // lazy singleton
+    this.instance = null;
+    this.injectionContext = injectionContext;
+    getOrCreateSingletonBeanProvider();
+  }
   /**
    * Creates a new IOC Bean reference
    *
@@ -57,10 +78,67 @@ public class AsyncSingletonBean<T> extends AsyncDependentBean<T> {
     return new AsyncSingletonBean<T>(
         beanManager, type, beanType, qualifiers, name, concrete, callback, instance, beanActivatorType);
   }
+  
+   public static <T> AsyncBeanDef<T> newBean(final AsyncBeanManagerImpl beanManager,
+         								    final Class<T> type,
+         								    final Class<?> beanType,
+         								    final Annotation[] qualifiers,
+          									final String name,
+          									final boolean concrete,
+          									final AsyncBeanProvider<T> callback,
+          									final AsyncCreationalContext context,
+          									final AsyncInjectionContext injectionContext,
+          									final Class<Object> beanActivatorType) {
+    return new AsyncSingletonBean<T>(
+    	beanManager, type, beanType, qualifiers, name, concrete, callback, context, injectionContext, beanActivatorType);
+  }
 
+  
   @Override
   public void getInstance(final CreationalCallback<T> callback, final AsyncCreationalContext context) {
-    callback.callback(instance);
+    SingletonBeanProvider<T> singletonBeanProvider = getOrCreateSingletonBeanProvider();
+    singletonBeanProvider.getInstance(callback);
+  }
+
+  private SingletonBeanProvider<T> getOrCreateSingletonBeanProvider() {
+    SingletonBeanProvider<T> singletonBeanProvider = beanManager.getLazySingleBeanProvider(beanType);
+    if (singletonBeanProvider == null) {
+      singletonBeanProvider = new SingletonBeanProvider<T>(instance) {
+        
+        AsyncCreationalContext currentContext;
+        
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        @Override
+        protected void getNewInstance(
+                final CreationalCallback<T> newInstanceCallback) {
+          //create with dependend context, that ensures the correct postContruct calling behaviour
+          currentContext = new AsyncCreationalContext(beanManager, Dependent.class);
+          currentContext.getSingletonInstanceOrNew(injectionContext, beanProvider, newInstanceCallback, type, (Class) beanType,getQualifiersAsArray(), name);
+        }
+
+        @Override
+        protected void onNewInstanceCreated(final T newInstance,
+                final CreationalCallback<T> callback) {
+          currentContext.finish(new Runnable() {
+            @Override
+            public void run() {
+              callback.callback(newInstance);
+            }
+          });
+        }
+
+        private Annotation[] getQualifiersAsArray() {
+          return qualifiers.toArray(new Annotation[qualifiers.size()]);
+        };
+      };
+      beanManager.putLazySingleBeanProvider(beanType, singletonBeanProvider);
+    }
+    return singletonBeanProvider;
+  }
+
+  @Override
+  public void getInstance(CreationalCallback<T> callback) {
+    getInstance(callback, null);
   }
 
   @Override
@@ -71,5 +149,22 @@ public class AsyncSingletonBean<T> extends AsyncDependentBean<T> {
   @Override
   public String toString() {
     return "AsyncSingletonBean [instance=" + instance + "]";
+  }
+
+  /**
+   * indicates wheter an instance is present or not
+   */
+  public boolean isReady() {
+    return getOrCreateSingletonBeanProvider().isReady();
+  }
+
+  public boolean isLazySingleton() {
+    return instance == null;
+  }
+
+  public void setInstance(T instance) {
+    if (isReady())
+      return;
+    getOrCreateSingletonBeanProvider().setInstance(instance);
   }
 }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/SingletonBeanProvider.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/async/SingletonBeanProvider.java
@@ -1,0 +1,90 @@
+package org.jboss.errai.ioc.client.container.async;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.jboss.errai.common.client.util.CreationalCallback;
+
+/**
+ * Returns the requested instance or retrieve it if its already available
+ * 
+ * have concurrency check build in
+ * 
+ * @author mariusgerwinn
+ * 
+ * @param <T>
+ */
+public abstract class SingletonBeanProvider<T> {
+
+  private static Logger log = Logger.getLogger(SingletonBeanProvider.class
+          .getName());
+
+  private T instance;
+
+  private boolean inProgressOfBeeingCreated;
+
+  private final List<CreationalCallback<T>> loadingCallbacks = new ArrayList<CreationalCallback<T>>();
+
+  /**
+   * in case of singleton this will be set immediatly
+   * 
+   * in case of lazy singleton this will be null
+   */
+  public SingletonBeanProvider(T instance) {
+    this.instance = instance;
+  }
+
+  public void setInstance(T instance) {
+    if (inProgressOfBeeingCreated) {
+      // skip to prevent loop & not calling postcontruct of that bean
+      return;
+    }
+    this.instance = instance;
+    // notifiy callbacks
+    for (CreationalCallback<T> c : loadingCallbacks) {
+      getInstance(c);
+    }
+    loadingCallbacks.clear();
+  }
+
+  public void getInstance(final CreationalCallback<T> callback) {
+    if (instance != null)
+      callback.callback(instance);
+    else {
+      loadingCallbacks.add(callback);
+      if (loadingCallbacks.size() <= 1) {
+        inProgressOfBeeingCreated = true;
+        getNewInstance(new CreationalCallback<T>() {
+
+          @Override
+          public void callback(T beanInstance) {
+            instance = beanInstance;
+            //call onInit
+            onNewInstanceCreated(instance, new CreationalCallback<T>() {
+              @Override
+              public void callback(T beanInstance) {
+                for (CreationalCallback<T> c : loadingCallbacks) {
+                  getInstance(c);
+                }
+                loadingCallbacks.clear();
+
+              }
+            });
+          }
+        });
+      }
+    }
+  }
+
+  // will be called right after instance is created so finish (postconstruct)
+  // can be invoked
+  protected abstract void onNewInstanceCreated(final T newInstance,
+          final CreationalCallback<T> callback);
+
+  protected abstract void getNewInstance(CreationalCallback<T> callback);
+
+  public boolean isReady() {
+    return instance != null;
+  }
+}

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/AbstractInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/AbstractInjector.java
@@ -66,6 +66,7 @@ public abstract class AbstractInjector implements Injector {
   private boolean created;
   private boolean rendered;
   protected boolean singleton;
+  protected boolean lazySingleton;
   protected boolean replaceable;
   protected boolean provider;
   protected boolean basic;
@@ -102,6 +103,10 @@ public abstract class AbstractInjector implements Injector {
   @Override
   public boolean isSingleton() {
     return singleton;
+  }
+  
+  public boolean isLazySingleton() {
+    return lazySingleton;
   }
 
   @Override

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/AsyncInjectUtil.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/AsyncInjectUtil.java
@@ -16,6 +16,15 @@
 
 package org.jboss.errai.ioc.rebind.ioc.injector;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Provider;
+
 import org.jboss.errai.codegen.Cast;
 import org.jboss.errai.codegen.Context;
 import org.jboss.errai.codegen.DefParameters;
@@ -50,14 +59,6 @@ import org.jboss.errai.ioc.rebind.ioc.injector.async.AsyncProxyInjector;
 import org.jboss.errai.ioc.rebind.ioc.injector.async.AsyncTypeInjector;
 import org.jboss.errai.ioc.rebind.ioc.metadata.QualifyingMetadata;
 
-import javax.inject.Provider;
-
-import java.lang.annotation.Annotation;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 public class AsyncInjectUtil {
   public static ConstructionStrategy getConstructionStrategy(final Injector injector, final InjectionContext ctx) {

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/Injector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/Injector.java
@@ -82,6 +82,13 @@ public interface Injector {
   boolean isSingleton();
 
   /**
+   * Checks if the injector for a lazySingleton bean.
+   *
+   * @return true if the injector handles a lazySingleton bean.
+   */
+  boolean isLazySingleton();
+  
+  /**
    * Check if the injector if of the dependent scope.
    *
    * @return true if the injector is of a dependent scope.

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AbstractAsyncInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AbstractAsyncInjector.java
@@ -37,13 +37,13 @@ public abstract class AbstractAsyncInjector extends AbstractInjector {
         
         statement =
             loadVariable(context.getProcessingContext().getContextVariableReference()).invoke("addBean",
-                getInjectedType(), getInjectedType(), Refs.get(getCreationalCallbackVarName()), isSingleton(),
+                getInjectedType(), getInjectedType(), Refs.get(getCreationalCallbackVarName()), isSingleton(), isLazySingleton(),
                 qualifyingMetadata.render(), beanName, true, Stmt.load(ab.value()));
       }
-      else {
+      else{
         statement =
             loadVariable(context.getProcessingContext().getContextVariableReference()).invoke("addBean",
-                getInjectedType(), getInjectedType(), Refs.get(getCreationalCallbackVarName()), isSingleton(),
+                getInjectedType(), getInjectedType(), Refs.get(getCreationalCallbackVarName()), isSingleton(), isLazySingleton(),
                 qualifyingMetadata.render(), beanName, true);
       }
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncContextualProviderInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncContextualProviderInjector.java
@@ -12,6 +12,7 @@ import org.jboss.errai.codegen.meta.MetaType;
 import org.jboss.errai.codegen.util.Refs;
 import org.jboss.errai.codegen.util.Stmt;
 import org.jboss.errai.common.client.util.CreationalCallback;
+import org.jboss.errai.ioc.client.LazySingleton;
 import org.jboss.errai.ioc.rebind.ioc.injector.InjectUtil;
 import org.jboss.errai.ioc.rebind.ioc.injector.Injector;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectableInstance;
@@ -38,7 +39,8 @@ public class AsyncContextualProviderInjector extends TypeInjector {
     this.testMock = context.isElementType(WiringElementType.TestMockBean, providerType);
     this.singleton = context.isElementType(WiringElementType.SingletonBean, providerType);
     this.alternative = context.isElementType(WiringElementType.AlternativeBean, providerType);
-
+ 	this.lazySingleton = type.getAnnotation(LazySingleton.class)!=null;
+ 	
     setRendered(true);
   }
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncProducerInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncProducerInjector.java
@@ -21,6 +21,7 @@ import org.jboss.errai.codegen.util.PrivateAccessType;
 import org.jboss.errai.codegen.util.Refs;
 import org.jboss.errai.codegen.util.Stmt;
 import org.jboss.errai.common.client.util.CreationalCallback;
+import org.jboss.errai.ioc.client.LazySingleton;
 import org.jboss.errai.ioc.client.api.qualifiers.BuiltInQualifiers;
 import org.jboss.errai.ioc.client.container.DestructionCallback;
 import org.jboss.errai.ioc.client.container.async.AsyncBeanContext;
@@ -83,6 +84,8 @@ public class AsyncProducerInjector extends AbstractAsyncInjector {
     this.producerInjectableInstance = producerInjectableInstance;
 
     this.singleton = injectionContext.isElementType(WiringElementType.SingletonBean, getProducerMember());
+
+    this.lazySingleton = getProducerMember().getAnnotation(LazySingleton.class)!=null;
 
     this.disposerMethod = findDisposerMethod(injectionContext.getProcessingContext());
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncProviderInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncProviderInjector.java
@@ -9,6 +9,7 @@ import org.jboss.errai.codegen.util.Refs;
 import org.jboss.errai.codegen.util.Stmt;
 import org.jboss.errai.common.client.util.CreationalCallback;
 import org.jboss.errai.config.rebind.EnvUtil;
+import org.jboss.errai.ioc.client.LazySingleton;
 import org.jboss.errai.ioc.rebind.ioc.injector.AbstractInjector;
 import org.jboss.errai.ioc.rebind.ioc.injector.InjectUtil;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectableInstance;
@@ -39,6 +40,7 @@ public class AsyncProviderInjector extends AsyncTypeInjector {
 
     this.testMock = context.isElementType(WiringElementType.TestMockBean, providerType);
     this.singleton = context.isElementType(WiringElementType.SingletonBean, providerType);
+    this.lazySingleton = type.getAnnotation(LazySingleton.class)!=null;
     this.alternative = context.isElementType(WiringElementType.AlternativeBean, type);
     setRendered(true);
   }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncQualifiedTypeInjectorDelegate.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncQualifiedTypeInjectorDelegate.java
@@ -38,14 +38,14 @@ public class AsyncQualifiedTypeInjectorDelegate extends QualifiedTypeInjectorDel
         context.getProcessingContext().appendToEnd(
             Stmt.loadVariable(context.getProcessingContext().getContextVariableReference())
                 .invoke("addBean", type, delegate.getInjectedType(), Refs.get(getCreationalCallbackVarName()),
-                    isSingleton(), md.render(), delegate.getBeanName(), false, Stmt.load(ab.value())));
+                    isSingleton(), isLazySingleton(), md.render(), delegate.getBeanName(), false, Stmt.load(ab.value())));
       }
       else {
       
       context.getProcessingContext().appendToEnd(
           Stmt.loadVariable(context.getProcessingContext().getContextVariableReference())
               .invoke("addBean", type, delegate.getInjectedType(), Refs.get(getCreationalCallbackVarName()),
-                  isSingleton(), md.render(), delegate.getBeanName(), false));
+                  isSingleton(), isLazySingleton(), md.render(), delegate.getBeanName(), false));
       }
       
       for (final RegistrationHook hook : getRegistrationHooks()) {

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/basic/ProducerInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/basic/ProducerInjector.java
@@ -5,6 +5,15 @@ import static org.jboss.errai.codegen.meta.MetaClassFactory.typeParametersOf;
 import static org.jboss.errai.codegen.util.Stmt.castTo;
 import static org.jboss.errai.codegen.util.Stmt.loadVariable;
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Specializes;
+import javax.inject.Named;
+
 import org.jboss.errai.codegen.Modifier;
 import org.jboss.errai.codegen.Parameter;
 import org.jboss.errai.codegen.Statement;
@@ -20,6 +29,7 @@ import org.jboss.errai.codegen.util.GenUtil;
 import org.jboss.errai.codegen.util.PrivateAccessType;
 import org.jboss.errai.codegen.util.Refs;
 import org.jboss.errai.codegen.util.Stmt;
+import org.jboss.errai.ioc.client.LazySingleton;
 import org.jboss.errai.ioc.client.api.qualifiers.BuiltInQualifiers;
 import org.jboss.errai.ioc.client.container.BeanProvider;
 import org.jboss.errai.ioc.client.container.CreationalContext;
@@ -39,14 +49,6 @@ import org.jboss.errai.ioc.rebind.ioc.injector.api.TypeDiscoveryListener;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.WiringElementType;
 import org.jboss.errai.ioc.rebind.ioc.metadata.JSR330QualifyingMetadata;
 import org.mvel2.util.ReflectionUtil;
-
-import javax.enterprise.inject.Disposes;
-import javax.enterprise.inject.Specializes;
-import javax.inject.Named;
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * @author Mike Brock
@@ -79,6 +81,8 @@ public class ProducerInjector extends AbstractInjector {
     this.producerInjectableInstance = producerInjectableInstance;
 
     this.singleton = injectionContext.isElementType(WiringElementType.SingletonBean, getProducerMember());
+
+	this.lazySingleton = getProducerMember().getAnnotation(LazySingleton.class)!=null;
 
     this.disposerMethod = findDisposerMethod(injectionContext.getProcessingContext());
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/basic/ProviderInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/basic/ProviderInjector.java
@@ -24,6 +24,7 @@ import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.codegen.util.Stmt;
 import org.jboss.errai.config.rebind.EnvUtil;
 import org.jboss.errai.config.util.ClassScanner;
+import org.jboss.errai.ioc.client.LazySingleton;
 import org.jboss.errai.ioc.rebind.ioc.injector.AbstractInjector;
 import org.jboss.errai.ioc.rebind.ioc.injector.Injector;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectableInstance;
@@ -54,7 +55,8 @@ public class ProviderInjector extends TypeInjector {
     this.testMock = context.isElementType(WiringElementType.TestMockBean, providerType);
     this.singleton = context.isElementType(WiringElementType.SingletonBean, providerType);
     this.alternative = context.isElementType(WiringElementType.AlternativeBean, type);
-
+ 	this.lazySingleton = type.getAnnotation(LazySingleton.class)!=null;
+ 
     GeneratorContext genCtx = context.getProcessingContext().getGeneratorContext();
     final Collection<MetaClass> toDisable = new ArrayList<MetaClass>(ClassScanner.getSubTypesOf(type, genCtx));
     toDisable.add(type);

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/basic/QualifiedTypeInjectorDelegate.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/basic/QualifiedTypeInjectorDelegate.java
@@ -73,6 +73,11 @@ public class QualifiedTypeInjectorDelegate extends AbstractInjector {
   public boolean isTestMock() {
     return delegate.isTestMock();
   }
+  
+  @Override
+  public boolean isLazySingleton(){
+      return delegate.isLazySingleton();
+  }
 
   @Override
   public boolean isSingleton() {

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/basic/TypeInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/basic/TypeInjector.java
@@ -39,6 +39,7 @@ import org.jboss.errai.codegen.builder.AnonymousClassStructureBuilder;
 import org.jboss.errai.codegen.builder.BlockBuilder;
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.codegen.util.Refs;
+import org.jboss.errai.ioc.client.LazySingleton;
 import org.jboss.errai.ioc.client.api.qualifiers.BuiltInQualifiers;
 import org.jboss.errai.ioc.client.container.BeanProvider;
 import org.jboss.errai.ioc.client.container.CreationalContext;
@@ -76,7 +77,8 @@ public class TypeInjector extends AbstractInjector {
     this.testMock = context.isElementType(WiringElementType.TestMockBean, type);
     this.singleton = context.isElementType(WiringElementType.SingletonBean, type);
     this.alternative = context.isElementType(WiringElementType.AlternativeBean, type);
-
+    this.lazySingleton = type.getAnnotation(LazySingleton.class)!=null;
+    
     this.instanceVarName = InjectUtil.getNewInjectorName().concat("_").concat(type.getName());
 
     final Set<Annotation> qualifiers = JSR330QualifyingMetadata.createSetFromAnnotations(type.getAnnotations());


### PR DESCRIPTION
This commit contains a more stable & cleaned up version of the lazy singleton scope usable in the async bean manager. My old pull request can be closed in favour of this one: https://github.com/errai/errai/pull/91

When adding test cases I encouraged some advanced IOC test setup problems. At least I think so ;)
Please take a look at them as well. These fixes are required for my test running properly.

Unfortunately I wasn't able to solve all the formatting related issues even with the used errai codestyle. I somehow got slightly different results on my side. 
