### PR TITLE
Fixed NullPointerException when sending error

### DIFF
--- a/errai-bus/src/main/java/org/jboss/errai/bus/server/security/auth/rules/RolesRequiredRule.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/server/security/auth/rules/RolesRequiredRule.java
@@ -87,7 +87,12 @@ public class RolesRequiredRule implements BooleanRoutingRule {
             .copyResource("Session", message)
             .errorsHandledBy(new ErrorCallback<Message>() {
               public boolean error(Message message, Throwable throwable) {
-                ErrorHelper.sendClientError(bus, message, throwable.getMessage(), throwable);
+			    if (null != throwable) {
+					ErrorHelper.sendClientError(bus, message, throwable.getMessage(), throwable);
+				}
+				else {
+					ErrorHelper.sendClientError(bus, message, "", throwable);
+				}
                 return false;
               }
             })


### PR DESCRIPTION
Potential null pointer exception, if error was introduced without
throwable as source.
