### PR TITLE
Code in ProducerInjector duplicated in AsyncProducerInjector 

### DIFF
--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/InjectorFactory.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/InjectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 JBoss, by Red Hat, Inc
+ * Copyright 2014 JBoss, by Red Hat, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,11 +28,10 @@ import org.jboss.errai.ioc.rebind.ioc.injector.async.AsyncProviderInjector;
 import org.jboss.errai.ioc.rebind.ioc.injector.async.AsyncQualifiedTypeInjectorDelegate;
 import org.jboss.errai.ioc.rebind.ioc.injector.async.AsyncTypeInjector;
 import org.jboss.errai.ioc.rebind.ioc.injector.basic.ContextualProviderInjector;
-import org.jboss.errai.ioc.rebind.ioc.injector.basic.ProducerInjector;
+import org.jboss.errai.ioc.rebind.ioc.injector.basic.SyncProducerInjector;
 import org.jboss.errai.ioc.rebind.ioc.injector.basic.ProviderInjector;
 import org.jboss.errai.ioc.rebind.ioc.injector.basic.QualifiedTypeInjectorDelegate;
 import org.jboss.errai.ioc.rebind.ioc.injector.basic.TypeInjector;
-import org.jboss.errai.ioc.rebind.ioc.metadata.QualifyingMetadata;
 
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
@@ -51,7 +50,7 @@ public class InjectorFactory {
     this.async = async;
 
     addInjector(BootstrapType.Synchronous, WiringElementType.Type, TypeInjector.class);
-    addInjector(BootstrapType.Synchronous, WiringElementType.ProducerElement, ProducerInjector.class);
+    addInjector(BootstrapType.Synchronous, WiringElementType.ProducerElement, SyncProducerInjector.class);
     addInjector(BootstrapType.Synchronous, WiringElementType.TopLevelProvider, ProviderInjector.class);
     addInjector(BootstrapType.Synchronous, WiringElementType.ContextualTopLevelProvider,
         ContextualProviderInjector.class);

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncProducerInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/async/AsyncProducerInjector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.errai.ioc.rebind.ioc.injector.async;
 
 import static org.jboss.errai.codegen.meta.MetaClassFactory.parameterizedAs;
@@ -16,7 +32,6 @@ import org.jboss.errai.codegen.meta.MetaClassMember;
 import org.jboss.errai.codegen.meta.MetaField;
 import org.jboss.errai.codegen.meta.MetaMethod;
 import org.jboss.errai.codegen.meta.MetaParameter;
-import org.jboss.errai.codegen.util.GenUtil;
 import org.jboss.errai.codegen.util.PrivateAccessType;
 import org.jboss.errai.codegen.util.Refs;
 import org.jboss.errai.codegen.util.Stmt;
@@ -27,7 +42,6 @@ import org.jboss.errai.ioc.client.container.async.AsyncBeanContext;
 import org.jboss.errai.ioc.client.container.async.AsyncBeanProvider;
 import org.jboss.errai.ioc.client.container.async.AsyncCreationalContext;
 import org.jboss.errai.ioc.rebind.ioc.bootstrapper.IOCProcessingContext;
-import org.jboss.errai.ioc.rebind.ioc.exception.InjectionFailure;
 import org.jboss.errai.ioc.rebind.ioc.injector.AsyncInjectUtil;
 import org.jboss.errai.ioc.rebind.ioc.injector.InjectUtil;
 import org.jboss.errai.ioc.rebind.ioc.injector.Injector;
@@ -39,8 +53,10 @@ import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectorRegistrationListener;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.RenderingHook;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.TypeDiscoveryListener;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.WiringElementType;
-import org.jboss.errai.ioc.rebind.ioc.injector.basic.ProducerInjector;
+import org.jboss.errai.ioc.rebind.ioc.injector.common.DelegatedProducerInjector;
+import org.jboss.errai.ioc.rebind.ioc.injector.common.ProducerInjector;
 import org.jboss.errai.ioc.rebind.ioc.metadata.JSR330QualifyingMetadata;
+import org.jboss.errai.ioc.rebind.ioc.metadata.QualifyingMetadata;
 import org.mvel2.util.ReflectionUtil;
 
 import javax.enterprise.inject.Disposes;
@@ -48,19 +64,16 @@ import javax.enterprise.inject.Specializes;
 import javax.inject.Named;
 
 import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
  * @author Mike Brock
  */
-public class AsyncProducerInjector extends AbstractAsyncInjector {
+public class AsyncProducerInjector extends AbstractAsyncInjector implements ProducerInjector {
   private final MetaClass injectedType;
   private final MetaClassMember producerMember;
   private final InjectableInstance producerInjectableInstance;
   private final MetaMethod disposerMethod;
-
   private boolean creationalCallbackRendered = false;
 
   public AsyncProducerInjector(final MetaClass injectedType,
@@ -98,7 +111,7 @@ public class AsyncProducerInjector extends AbstractAsyncInjector {
         .createFrom(qualifiers.toArray(new Annotation[qualifiers.size()]));
 
     if (producerMember.isAnnotationPresent(Specializes.class)) {
-      makeSpecialized(injectionContext);
+      new DelegatedProducerInjector(this).makeSpecialized(injectionContext);
     }
 
     if (producerMember.isAnnotationPresent(Named.class)) {
@@ -404,74 +417,6 @@ public class AsyncProducerInjector extends AbstractAsyncInjector {
     }
   }
 
-  private void makeSpecialized(final InjectionContext context) {
-    final MetaClass type = getInjectedType();
-
-    if (!(producerMember instanceof MetaMethod)) {
-      throw new InjectionFailure("cannot specialize a field-based producer: " + producerMember);
-    }
-
-    final MetaMethod producerMethod = (MetaMethod) producerMember;
-
-    if (producerMethod.isStatic()) {
-      throw new InjectionFailure("cannot specialize a static producer method: " + producerMethod);
-    }
-
-    if (type.getSuperClass().getFullyQualifiedName().equals(Object.class.getName())) {
-      throw new InjectionFailure("the specialized producer " + producerMember + " must override "
-          + "another producer");
-    }
-
-    context.addInjectorRegistrationListener(getInjectedType(),
-        new InjectorRegistrationListener() {
-          @Override
-          public void onRegister(final MetaClass type, final Injector injector) {
-            MetaClass cls = producerMember.getDeclaringClass();
-            while ((cls = cls.getSuperClass()) != null && !cls.getFullyQualifiedName().equals(Object.class.getName())) {
-              if (!context.hasInjectorForType(cls)) {
-                context.addType(cls);
-              }
-
-              final MetaMethod declaredMethod
-                  = cls.getDeclaredMethod(producerMethod.getName(), GenUtil.fromParameters(producerMethod.getParameters()));
-
-              context.declareOverridden(declaredMethod);
-
-              updateQualifiersAndName(producerMethod, context);
-            }
-          }
-        });
-  }
-
-  private void updateQualifiersAndName(final MetaMethod producerMethod, final InjectionContext context) {
-    if (!context.hasInjectorForType(getInjectedType())) return;
-
-    final Set<Annotation> qualifiers = new HashSet<Annotation>();
-    qualifiers.addAll(Arrays.asList(qualifyingMetadata.getQualifiers()));
-
-    for (final Injector injector : context.getInjectors(getInjectedType())) {
-      if (injector != this
-          && injector instanceof ProducerInjector
-          && methodSignatureMaches((MetaMethod) ((AsyncProducerInjector) injector).producerMember, producerMethod)) {
-
-        if (this.beanName == null) {
-          this.beanName = injector.getBeanName();
-        }
-
-        injector.setEnabled(false);
-        qualifiers.addAll(Arrays.asList(injector.getQualifyingMetadata().getQualifiers()));
-      }
-    }
-
-    qualifyingMetadata = context.getProcessingContext()
-        .getQualifyingMetadataFactory().createFrom(qualifiers.toArray(new Annotation[qualifiers.size()]));
-  }
-
-  private static boolean methodSignatureMaches(final MetaMethod a, final MetaMethod b) {
-    return a.getName().equals(b.getName())
-        && Arrays.equals(GenUtil.fromParameters(a.getParameters()), GenUtil.fromParameters(b.getParameters()));
-  }
-
   @Override
   public boolean isStatic() {
     return getProducerMember().isStatic();
@@ -479,6 +424,16 @@ public class AsyncProducerInjector extends AbstractAsyncInjector {
 
   public MetaClassMember getProducerMember() {
     return producerMember;
+  }
+
+  @Override
+  public void setQualifyingMetadata(QualifyingMetadata qualifyingMetadata) {
+    this.qualifyingMetadata = qualifyingMetadata;
+  }
+
+  @Override
+  public void setBeanName(String beanName) {
+    this.beanName = beanName;
   }
 
   @Override

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/common/DelegatedProducerInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/common/DelegatedProducerInjector.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2014 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.rebind.ioc.injector.common;
+
+import org.jboss.errai.codegen.meta.MetaClass;
+import org.jboss.errai.codegen.meta.MetaClassMember;
+import org.jboss.errai.codegen.meta.MetaMethod;
+import org.jboss.errai.codegen.util.GenUtil;
+import org.jboss.errai.ioc.rebind.ioc.exception.InjectionFailure;
+import org.jboss.errai.ioc.rebind.ioc.injector.Injector;
+import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectionContext;
+import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectorRegistrationListener;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A {@link DelegatedProducerInjector} collects methods that are common for
+ * {@link org.jboss.errai.ioc.rebind.ioc.injector.basic.SyncProducerInjector} and
+ * {@link org.jboss.errai.ioc.rebind.ioc.injector.async.AsyncProducerInjector}
+ *
+ * @author Alexander Buyanov
+ */
+public class DelegatedProducerInjector {
+  /**
+   * The reference to {@link ProducerInjector}
+   */
+  private final ProducerInjector injector;
+
+
+  public DelegatedProducerInjector(ProducerInjector injector) {
+    this.injector = injector;
+  }
+
+  /**
+   *
+   * @param context the {@link org.jboss.errai.ioc.rebind.ioc.injector.api.InjectionContext} reference
+   *                to add {@link org.jboss.errai.ioc.rebind.ioc.injector.api.InjectorRegistrationListener}
+   */
+
+  public void makeSpecialized(final InjectionContext context) {
+    final MetaClass type = injector.getInjectedType();
+    final MetaClassMember producerMember = injector.getProducerMember();
+
+    if (!(producerMember instanceof MetaMethod)) {
+      throw new InjectionFailure("cannot specialize a field-based producer: " + producerMember);
+    }
+    final MetaMethod producerMethod = (MetaMethod) producerMember;
+
+    if (producerMethod.isStatic()) {
+      throw new InjectionFailure("cannot specialize a static producer method: " + producerMethod);
+    }
+
+    if (type.getSuperClass().getFullyQualifiedName().equals(Object.class.getName())) {
+      throw new InjectionFailure("the specialized producer " + producerMember + " must override "
+          + "another producer");
+    }
+
+    context.addInjectorRegistrationListener(injector.getInjectedType(),
+        new InjectorRegistrationListener() {
+          @Override
+          public void onRegister(final MetaClass type, final Injector injector) {
+            MetaClass cls = producerMember.getDeclaringClass();
+            while ((cls = cls.getSuperClass()) != null && !cls.getFullyQualifiedName().equals(Object.class.getName())) {
+              if (!context.hasInjectorForType(cls)) {
+                context.addType(cls);
+              }
+
+              final MetaMethod declaredMethod
+                  = cls.getDeclaredMethod(producerMethod.getName(), GenUtil.fromParameters(producerMethod.getParameters()));
+
+              context.declareOverridden(declaredMethod);
+
+              updateQualifiersAndName(producerMethod, context);
+            }
+          }
+        });
+  }
+
+  private void updateQualifiersAndName(final MetaMethod producerMethod, final InjectionContext context) {
+    if (!context.hasInjectorForType(injector.getInjectedType())) return;
+
+    final Set<Annotation> qualifiers = new HashSet<Annotation>();
+    qualifiers.addAll(Arrays.asList(injector.getQualifyingMetadata().getQualifiers()));
+
+    for (final Injector inj : context.getInjectors(injector.getInjectedType())) {
+      if (inj != this
+          && inj instanceof ProducerInjector
+          && methodSignatureMatches((MetaMethod) ((ProducerInjector) inj).getProducerMember(), producerMethod)) {
+
+        if (injector.getBeanName() == null) {
+          injector.setBeanName(inj.getBeanName());
+        }
+
+        inj.setEnabled(false);
+        qualifiers.addAll(Arrays.asList(inj.getQualifyingMetadata().getQualifiers()));
+      }
+    }
+
+    injector.setQualifyingMetadata(context.getProcessingContext()
+        .getQualifyingMetadataFactory().createFrom(qualifiers.toArray(new Annotation[qualifiers.size()])));
+  }
+
+  private static boolean methodSignatureMatches(final MetaMethod a, final MetaMethod b) {
+    return a.getName().equals(b.getName())
+        && Arrays.equals(GenUtil.fromParameters(a.getParameters()), GenUtil.fromParameters(b.getParameters()));
+  }
+}

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/common/ProducerInjector.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/injector/common/ProducerInjector.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.rebind.ioc.injector.common;
+
+import org.jboss.errai.codegen.meta.MetaClass;
+import org.jboss.errai.codegen.meta.MetaClassMember;
+import org.jboss.errai.ioc.rebind.ioc.metadata.QualifyingMetadata;
+
+/**
+ * Interface {@link ProducerInjector} to abstract
+ * {@link org.jboss.errai.ioc.rebind.ioc.injector.basic.SyncProducerInjector} and
+ * {@link org.jboss.errai.ioc.rebind.ioc.injector.async.AsyncProducerInjector}
+ *
+ * @author Alexander Buyanov
+ */
+public interface ProducerInjector {
+  MetaClass getInjectedType();
+
+  MetaClassMember getProducerMember();
+
+  QualifyingMetadata getQualifyingMetadata();
+
+  void setQualifyingMetadata(QualifyingMetadata qualifyingMetadata);
+
+  String getBeanName();
+
+  void setBeanName(String beanName);
+}


### PR DESCRIPTION
Three private methods (makeSpecialized, updateQualifiersAndName and methodSignatureMatches) was completely equal in ProducerInjector and AsyncProducerInjector classes.

I tried to put these method to their common ancestor, but code becomes uglier than it was, so I moved them to separate class.

As I'm new to this project, I don't know where is it a good idea, but I hope this change will make it easier to maintain errai.

P.S. May be names of new class & interface are not good, please change them if you construct better ones.
