### PR TITLE
Collapse all properties

### DIFF
--- a/errai-demos/errai-bus-demo-stock/src/main/java/org/errai/samples/stockdemo/StockDemo.gwt.xml
+++ b/errai-demos/errai-bus-demo-stock/src/main/java/org/errai/samples/stockdemo/StockDemo.gwt.xml
@@ -26,4 +26,7 @@
   <entry-point class="org.errai.samples.stockdemo.client.local.StockClient"/>
   <source path="client"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-bus-demo-stock/src/main/java/org/errai/samples/stockdemo/StockDemo.gwt.xml
+++ b/errai-demos/errai-bus-demo-stock/src/main/java/org/errai/samples/stockdemo/StockDemo.gwt.xml
@@ -1,5 +1,4 @@
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-    "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  JBoss, Home of Professional Open Source
  Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -16,10 +15,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
+
 <module rename-to="App">
-    <inherits name='com.google.gwt.user.User' />
-    <inherits name="com.google.gwt.uibinder.UiBinder" />
-    <inherits name="org.jboss.errai.bus.ErraiBus" />
-    <entry-point class="org.errai.samples.stockdemo.client.local.StockClient" />
-    <source path="client" />
+
+  <inherits name='com.google.gwt.user.User'/>
+  <inherits name="com.google.gwt.uibinder.UiBinder"/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
+  <entry-point class="org.errai.samples.stockdemo.client.local.StockClient"/>
+  <source path="client"/>
+
 </module>

--- a/errai-demos/errai-bus-demo-stress-test/src/main/java/org/jboss/errai/demo/busstress/App.gwt.xml
+++ b/errai-demos/errai-bus-demo-stress-test/src/main/java/org/jboss/errai/demo/busstress/App.gwt.xml
@@ -24,4 +24,7 @@
   <inherits name="org.jboss.errai.bus.ErraiBus"/>
   <inherits name="org.jboss.errai.ioc.Container"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-bus-demo-stress-test/src/main/java/org/jboss/errai/demo/busstress/App.gwt.xml
+++ b/errai-demos/errai-bus-demo-stress-test/src/main/java/org/jboss/errai/demo/busstress/App.gwt.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  JBoss, Home of Professional Open Source
  Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -14,11 +15,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
 
 <module rename-to="App">
-    <inherits name='com.google.gwt.user.User' />
-    <inherits name="org.jboss.errai.bus.ErraiBus" />
-    <inherits name="org.jboss.errai.ioc.Container" />
+
+  <inherits name='com.google.gwt.user.User'/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
+  <inherits name="org.jboss.errai.ioc.Container"/>
+
 </module>

--- a/errai-demos/errai-cdi-demo-mobile/src/main/java/org/jboss/errai/demo/mobile/ErraiCdiMobileDemo.gwt.xml
+++ b/errai-demos/errai-cdi-demo-mobile/src/main/java/org/jboss/errai/demo/mobile/ErraiCdiMobileDemo.gwt.xml
@@ -29,4 +29,7 @@
   <public path="resources"></public>
   <stylesheet src="style.css"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-cdi-demo-mobile/src/main/java/org/jboss/errai/demo/mobile/ErraiCdiMobileDemo.gwt.xml
+++ b/errai-demos/errai-cdi-demo-mobile/src/main/java/org/jboss/errai/demo/mobile/ErraiCdiMobileDemo.gwt.xml
@@ -15,15 +15,18 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
-<module rename-to="ErraiCdiMobileDemo">
-    <inherits name="org.jboss.errai.common.ErraiCommon" />
-    <inherits name="org.jboss.errai.ioc.Container" />
-    <inherits name="org.jboss.errai.enterprise.CDI" />
-    <inherits name="com.google.gwt.animation.Animation" />
-    <inherits name="org.jboss.errai.orientation.Location" />
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
 
-    <public path="resources"></public>
-    <stylesheet src="style.css" />
+<module rename-to="ErraiCdiMobileDemo">
+
+  <inherits name="org.jboss.errai.common.ErraiCommon"/>
+  <inherits name="org.jboss.errai.ioc.Container"/>
+  <inherits name="org.jboss.errai.enterprise.CDI"/>
+  <inherits name="com.google.gwt.animation.Animation"/>
+  <inherits name="org.jboss.errai.orientation.Location"/>
+
+  <public path="resources"></public>
+  <stylesheet src="style.css"/>
+
 </module>

--- a/errai-demos/errai-cdi-demo-mvp/src/main/java/org/jboss/errai/cdi/demo/mvp/Contacts.gwt.xml
+++ b/errai-demos/errai-cdi-demo-mvp/src/main/java/org/jboss/errai/cdi/demo/mvp/Contacts.gwt.xml
@@ -32,4 +32,7 @@
   <!-- Specify the paths for translatable code -->
   <source path='client'/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-cdi-demo-mvp/src/main/java/org/jboss/errai/cdi/demo/mvp/Contacts.gwt.xml
+++ b/errai-demos/errai-cdi-demo-mvp/src/main/java/org/jboss/errai/cdi/demo/mvp/Contacts.gwt.xml
@@ -15,19 +15,21 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
 
 <module rename-to='contacts'>
-    <inherits name='com.google.gwt.user.User' />
-    <inherits name='com.google.gwt.user.theme.standard.Standard' />
 
-    <inherits name="org.jboss.errai.common.ErraiCommon" />
-    <inherits name="org.jboss.errai.bus.ErraiBus" />
-    <inherits name="org.jboss.errai.ioc.Container" />
-    <inherits name="org.jboss.errai.enterprise.CDI" />
-    <inherits name="org.jboss.errai.uibinder.UIBinderForIOC" />
+  <inherits name='com.google.gwt.user.User'/>
+  <inherits name='com.google.gwt.user.theme.standard.Standard'/>
 
-    <!-- Specify the paths for translatable code -->
-    <source path='client' />
+  <inherits name="org.jboss.errai.common.ErraiCommon"/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
+  <inherits name="org.jboss.errai.ioc.Container"/>
+  <inherits name="org.jboss.errai.enterprise.CDI"/>
+  <inherits name="org.jboss.errai.uibinder.UIBinderForIOC"/>
+
+  <!-- Specify the paths for translatable code -->
+  <source path='client'/>
+
 </module>

--- a/errai-demos/errai-cdi-demo-tagcloud/src/main/java/org/jboss/errai/cdi/demo/tagcloud/TagCloudDemo.gwt.xml
+++ b/errai-demos/errai-cdi-demo-tagcloud/src/main/java/org/jboss/errai/cdi/demo/tagcloud/TagCloudDemo.gwt.xml
@@ -15,11 +15,14 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
+
 <module rename-to="TagCloudDemo">
-    <inherits name="org.jboss.errai.common.ErraiCommon" />
-    <inherits name="org.jboss.errai.bus.ErraiBus" />
-    <inherits name="org.jboss.errai.ioc.Container" />
-    <inherits name="org.jboss.errai.enterprise.CDI" />
+
+  <inherits name="org.jboss.errai.common.ErraiCommon"/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
+  <inherits name="org.jboss.errai.ioc.Container"/>
+  <inherits name="org.jboss.errai.enterprise.CDI"/>
+
 </module>

--- a/errai-demos/errai-cdi-demo-tagcloud/src/main/java/org/jboss/errai/cdi/demo/tagcloud/TagCloudDemo.gwt.xml
+++ b/errai-demos/errai-cdi-demo-tagcloud/src/main/java/org/jboss/errai/cdi/demo/tagcloud/TagCloudDemo.gwt.xml
@@ -25,4 +25,7 @@
   <inherits name="org.jboss.errai.ioc.Container"/>
   <inherits name="org.jboss.errai.enterprise.CDI"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-jaxrs-demo-crud/src/main/java/org/jboss/errai/samples/restdemo/RestDemo.gwt.xml
+++ b/errai-demos/errai-jaxrs-demo-crud/src/main/java/org/jboss/errai/samples/restdemo/RestDemo.gwt.xml
@@ -25,4 +25,7 @@
   <inherits name="org.jboss.errai.ioc.Container"/>
   <inherits name='com.google.gwt.junit.JUnit'/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-jaxrs-demo-crud/src/main/java/org/jboss/errai/samples/restdemo/RestDemo.gwt.xml
+++ b/errai-demos/errai-jaxrs-demo-crud/src/main/java/org/jboss/errai/samples/restdemo/RestDemo.gwt.xml
@@ -1,10 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ JBoss, Home of Professional Open Source
+ Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ contributors by the @authors tag. See the copyright.txt in the
+ distribution for a full listing of individual contributors.
 
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
 
 <module rename-to="RestDemo">
+
   <inherits name="com.google.gwt.user.User"/>
   <inherits name="org.jboss.errai.enterprise.Jaxrs"/>
-  <inherits name="org.jboss.errai.ioc.Container"/> 
-  <inherits name='com.google.gwt.junit.JUnit' />
+  <inherits name="org.jboss.errai.ioc.Container"/>
+  <inherits name='com.google.gwt.junit.JUnit'/>
+
 </module>

--- a/errai-demos/errai-jpa-demo-basic/src/main/java/org/jboss/errai/demo/jpa/ErraiJpaDemo.gwt.xml
+++ b/errai-demos/errai-jpa-demo-basic/src/main/java/org/jboss/errai/demo/jpa/ErraiJpaDemo.gwt.xml
@@ -26,4 +26,7 @@
 
   <set-property name="user.agent" value="gecko1_8,safari"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-jpa-demo-basic/src/main/java/org/jboss/errai/demo/jpa/ErraiJpaDemo.gwt.xml
+++ b/errai-demos/errai-jpa-demo-basic/src/main/java/org/jboss/errai/demo/jpa/ErraiJpaDemo.gwt.xml
@@ -15,12 +15,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
-<module rename-to="ErraiJpaDemo">
-    <inherits name="org.jboss.errai.jpa.JPA" />
-    <inherits name="org.jboss.errai.enterprise.CDI" />
-    <inherits name='com.google.gwt.user.theme.clean.Clean' />
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
 
-    <set-property name="user.agent" value="gecko1_8,safari" />
+<module rename-to="ErraiJpaDemo">
+
+  <inherits name="org.jboss.errai.jpa.JPA"/>
+  <inherits name="org.jboss.errai.enterprise.CDI"/>
+  <inherits name='com.google.gwt.user.theme.clean.Clean'/>
+
+  <set-property name="user.agent" value="gecko1_8,safari"/>
+
 </module>

--- a/errai-demos/errai-jpa-demo-grocery-list/src/main/java/org/jboss/errai/demo/grocery/GroceryList.gwt.xml
+++ b/errai-demos/errai-jpa-demo-grocery-list/src/main/java/org/jboss/errai/demo/grocery/GroceryList.gwt.xml
@@ -42,4 +42,7 @@
   <source path="client"/>
   <source path="shared"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-jpa-demo-grocery-list/src/main/java/org/jboss/errai/demo/grocery/GroceryList.gwt.xml
+++ b/errai-demos/errai-jpa-demo-grocery-list/src/main/java/org/jboss/errai/demo/grocery/GroceryList.gwt.xml
@@ -15,29 +15,31 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
+
 <module rename-to="GroceryList">
-    <inherits name="org.jboss.errai.jpa.JPA" />
-    <inherits name="org.jboss.errai.common.ErraiCommon" />
-    <inherits name="org.jboss.errai.bus.ErraiBus" />
-    <inherits name="org.jboss.errai.ioc.Container" />
-    <inherits name="org.jboss.errai.ui.UI" />
-    <inherits name="org.jboss.errai.ui.nav.Navigation" />
-    <inherits name="org.jboss.errai.databinding.DataBinding" />
-    <inherits name="org.jboss.errai.enterprise.CDI" />
-    <inherits name="com.google.gwt.maps.Maps" />
-    <inherits name="org.gwtopenmaps.openlayers.OpenLayers" />
-    <inherits name="org.jboss.errai.ui.Cordova" />
-    <inherits name="com.google.gwt.gen2.picker.Picker" />
-    <inherits name="org.jboss.errai.validation.Validation" />
-    <inherits name="org.hibernate.validator.HibernateValidator" />
 
-    <replace-with class="org.jboss.errai.demo.grocery.client.local.Config">
-        <when-type-is class="org.jboss.errai.bus.client.framework.Configuration" />
-    </replace-with>
+  <inherits name="org.jboss.errai.jpa.JPA"/>
+  <inherits name="org.jboss.errai.common.ErraiCommon"/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
+  <inherits name="org.jboss.errai.ioc.Container"/>
+  <inherits name="org.jboss.errai.ui.UI"/>
+  <inherits name="org.jboss.errai.ui.nav.Navigation"/>
+  <inherits name="org.jboss.errai.databinding.DataBinding"/>
+  <inherits name="org.jboss.errai.enterprise.CDI"/>
+  <inherits name="com.google.gwt.maps.Maps"/>
+  <inherits name="org.gwtopenmaps.openlayers.OpenLayers"/>
+  <inherits name="org.jboss.errai.ui.Cordova"/>
+  <inherits name="com.google.gwt.gen2.picker.Picker"/>
+  <inherits name="org.jboss.errai.validation.Validation"/>
+  <inherits name="org.hibernate.validator.HibernateValidator"/>
 
-    <source path="client" />
-    <source path="shared" />
+  <replace-with class="org.jboss.errai.demo.grocery.client.local.Config">
+    <when-type-is class="org.jboss.errai.bus.client.framework.Configuration"/>
+  </replace-with>
+
+  <source path="client"/>
+  <source path="shared"/>
 
 </module>

--- a/errai-demos/errai-jpa-demo-todo-list/src/main/java/org/jboss/errai/demo/todo/TodoList.gwt.xml
+++ b/errai-demos/errai-jpa-demo-todo-list/src/main/java/org/jboss/errai/demo/todo/TodoList.gwt.xml
@@ -38,4 +38,7 @@
   <inherits name="org.jboss.errai.enterprise.Jaxrs"/>
   <inherits name="org.jboss.errai.jpa.JPA"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-jpa-demo-todo-list/src/main/java/org/jboss/errai/demo/todo/TodoList.gwt.xml
+++ b/errai-demos/errai-jpa-demo-todo-list/src/main/java/org/jboss/errai/demo/todo/TodoList.gwt.xml
@@ -1,21 +1,41 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ JBoss, Home of Professional Open Source
+ Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ contributors by the @authors tag. See the copyright.txt in the
+ distribution for a full listing of individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
+
 <module rename-to="TodoList">
 
-    <!-- The following two items will eventually be merged into the above supermodule -->
-    <inherits name="org.jboss.errai.jpa.sync.DataSync"/>
-    <inherits name="org.jboss.errai.validation.Validation"/>
-    <inherits name="org.hibernate.validator.HibernateValidator"/>
+  <!-- The following two items will eventually be merged into the above supermodule -->
+  <inherits name="org.jboss.errai.jpa.sync.DataSync"/>
+  <inherits name="org.jboss.errai.validation.Validation"/>
+  <inherits name="org.hibernate.validator.HibernateValidator"/>
   <inherits name="org.jboss.errai.security.Security"/>
 
   <source path="client"/>
-    <source path="shared"/>    
-<inherits name="com.google.gwt.user.User"/>
-<inherits name="org.jboss.errai.bus.ErraiBus"/>
-<inherits name="org.jboss.errai.ioc.Container"/>
-<inherits name="org.jboss.errai.enterprise.CDI"/>
-<inherits name="org.jboss.errai.ui.UI"/>
-<inherits name="org.jboss.errai.ui.nav.Navigation"/>
-<inherits name="org.jboss.errai.databinding.DataBinding"/>
-<inherits name="org.jboss.errai.enterprise.Jaxrs"/>
-<inherits name="org.jboss.errai.jpa.JPA"/>
+  <source path="shared"/>
+  <inherits name="com.google.gwt.user.User"/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
+  <inherits name="org.jboss.errai.ioc.Container"/>
+  <inherits name="org.jboss.errai.enterprise.CDI"/>
+  <inherits name="org.jboss.errai.ui.UI"/>
+  <inherits name="org.jboss.errai.ui.nav.Navigation"/>
+  <inherits name="org.jboss.errai.databinding.DataBinding"/>
+  <inherits name="org.jboss.errai.enterprise.Jaxrs"/>
+  <inherits name="org.jboss.errai.jpa.JPA"/>
+
 </module>

--- a/errai-demos/errai-security-demo/src/main/java/org/jboss/errai/security/demo/App.gwt.xml
+++ b/errai-demos/errai-security-demo/src/main/java/org/jboss/errai/security/demo/App.gwt.xml
@@ -35,4 +35,7 @@
 
   <set-property name="user.agent" value="safari"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>

--- a/errai-demos/errai-security-demo/src/main/java/org/jboss/errai/security/demo/App.gwt.xml
+++ b/errai-demos/errai-security-demo/src/main/java/org/jboss/errai/security/demo/App.gwt.xml
@@ -1,20 +1,38 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN" "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ JBoss, Home of Professional Open Source
+ Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ contributors by the @authors tag. See the copyright.txt in the
+ distribution for a full listing of individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
+
 <module rename-to="app">
 
-  <inherits name="org.jboss.errai.common.ErraiCommon" />
-  <inherits name="org.jboss.errai.bus.ErraiBus" />
-  <inherits name="org.jboss.errai.ioc.Container" />
-  <inherits name="org.jboss.errai.ui.UI" />
-  <inherits name="org.jboss.errai.databinding.DataBinding" />
-  <inherits name="org.jboss.errai.ui.nav.Navigation" />
-  <inherits name="org.jboss.errai.enterprise.CDI" />
-  <inherits name="org.jboss.errai.enterprise.Jaxrs" />
-  <inherits name="org.jboss.errai.security.Security" />
-  <inherits name="org.jboss.errai.security.SecurityShared" />
+  <inherits name="org.jboss.errai.common.ErraiCommon"/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
+  <inherits name="org.jboss.errai.ioc.Container"/>
+  <inherits name="org.jboss.errai.ui.UI"/>
+  <inherits name="org.jboss.errai.databinding.DataBinding"/>
+  <inherits name="org.jboss.errai.ui.nav.Navigation"/>
+  <inherits name="org.jboss.errai.enterprise.CDI"/>
+  <inherits name="org.jboss.errai.enterprise.Jaxrs"/>
+  <inherits name="org.jboss.errai.security.Security"/>
+  <inherits name="org.jboss.errai.security.SecurityShared"/>
 
-  <inherits name="com.google.gwt.user.User" />
+  <inherits name="com.google.gwt.user.User"/>
 
-  <set-property name="user.agent" value="safari" />
+  <set-property name="user.agent" value="safari"/>
 
 </module>

--- a/errai-demos/errai-ui-demo-i18n/src/main/java/org/errai/samples/i18ndemo/App.gwt.xml
+++ b/errai-demos/errai-ui-demo-i18n/src/main/java/org/errai/samples/i18ndemo/App.gwt.xml
@@ -1,6 +1,25 @@
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 1.6//EN"
-        "http://google-web-toolkit.googlecode.com/svn/releases/1.6/distro-source/core/src/gwt-module.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ JBoss, Home of Professional Open Source
+ Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ contributors by the @authors tag. See the copyright.txt in the
+ distribution for a full listing of individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.6//EN"
+    "http://www.gwtproject.org/doctype/2.6.1/gwt-module.dtd">
 
 <module rename-to="App">
-  <inherits name="org.jboss.errai.enterprise.All" />
+
+  <inherits name="org.jboss.errai.enterprise.All"/>
+
 </module>

--- a/errai-demos/errai-ui-demo-i18n/src/main/java/org/errai/samples/i18ndemo/App.gwt.xml
+++ b/errai-demos/errai-ui-demo-i18n/src/main/java/org/errai/samples/i18ndemo/App.gwt.xml
@@ -22,4 +22,7 @@
 
   <inherits name="org.jboss.errai.enterprise.All"/>
 
+  <!-- Cut down compilation time by limiting the permutations to a single bigger one.  -->
+  <collapse-all-properties/>
+
 </module>


### PR DESCRIPTION
Collapse all properties to cut down the compilation time in the demos.

On my notebook:
`mvn clean verify` of Errai
before: ~10m
after: ~6m