### PR TITLE
check if user has RequiredRoles and delegating the query to PicketLink

### DIFF
--- a/errai-security/errai-security-picketlink/src/main/java/org/jboss/errai/security/server/PicketLinkBasicModelServices.java
+++ b/errai-security/errai-security-picketlink/src/main/java/org/jboss/errai/security/server/PicketLinkBasicModelServices.java
@@ -1,0 +1,66 @@
+package org.jboss.errai.security.server;
+
+import org.picketlink.idm.IdentityManagementException;
+import org.picketlink.idm.model.Account;
+import org.picketlink.idm.model.IdentityType;
+import org.picketlink.idm.model.basic.Group;
+import org.picketlink.idm.model.basic.Role;
+
+public interface PicketLinkBasicModelServices {
+
+  /**
+   * <p>
+   * Returns an {@link Role} instance with the given <code>name</code>.
+   * </p>
+   *
+   * @param name
+   *          The role's name.
+   *
+   * @return An {@link Role} instance or null if the <code>name</code> is null
+   *         or an empty string.
+   *
+   * @throws IdentityManagementException
+   *           If the method fails.
+   */
+  Role getRole(String name) throws IdentityManagementException;
+
+  /**
+   * <p>
+   * Checks if the given {@link Role} is granted to the provided
+   * {@link IdentityType}.
+   * </p>
+   *
+   * @param assignee
+   *          A previously loaded {@link IdentityType} instance. Valid instances
+   *          are only from the {@link Account} and {@link Group} types.
+   * @param role
+   *          A previously loaded {@link Role} instance.
+   *
+   * @return True if the give {@link Role} is granted. Otherwise this method
+   *         returns false.
+   *
+   * @throws IdentityManagementException
+   *           If the method fails.
+   */
+  boolean hasRole(IdentityType assignee, Role role) throws IdentityManagementException;
+
+  /**
+   * <p>
+   * Checks if the given {@link Role} is granted to the provided
+   * {@link IdentityType}.
+   * </p>
+   *
+   * @param assignee
+   *          A previously loaded {@link IdentityType} instance. Valid instances
+   *          are only from the {@link Account} and {@link Group} types.
+   * @param role
+   *          A previously loaded {@link Role} instance.
+   *
+   * @return True if the give {@link Role} is granted. Otherwise this method
+   *         returns false.
+   *
+   * @throws IdentityManagementException
+   *           If the method fails.
+   */
+  boolean hasRole(IdentityType assignee, String roleName) throws IdentityManagementException;
+}

--- a/errai-security/errai-security-picketlink/src/main/java/org/jboss/errai/security/server/PicketLinkBasicModelServicesImpl.java
+++ b/errai-security/errai-security-picketlink/src/main/java/org/jboss/errai/security/server/PicketLinkBasicModelServicesImpl.java
@@ -1,0 +1,36 @@
+package org.jboss.errai.security.server;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.picketlink.idm.IdentityManagementException;
+import org.picketlink.idm.IdentityManager;
+import org.picketlink.idm.RelationshipManager;
+import org.picketlink.idm.model.IdentityType;
+import org.picketlink.idm.model.basic.BasicModel;
+import org.picketlink.idm.model.basic.Role;
+
+@Dependent
+public class PicketLinkBasicModelServicesImpl implements PicketLinkBasicModelServices {
+  @Inject
+  private IdentityManager identityManager;
+
+  @Inject
+  private RelationshipManager relationshipManager;
+
+  @Override
+  public Role getRole(String name) throws IdentityManagementException {
+    return BasicModel.getRole(identityManager, name);
+  }
+
+  @Override
+  public boolean hasRole(IdentityType assignee, Role role) throws IdentityManagementException {
+    return BasicModel.hasRole(relationshipManager, assignee, role);
+  }
+
+  @Override
+  public boolean hasRole(IdentityType assignee, String roleName) throws IdentityManagementException {
+    Role role = getRole(roleName);
+    return role != null && BasicModel.hasRole(relationshipManager, assignee, role);
+  }
+}


### PR DESCRIPTION
The main idea of this change is to check if a user has the Roles asking that to PicketLink.
The previous version only checked if the user was directly granted a role, but if the user has the role for being a member of a group has the role the client received no roles.