### PR TITLE
Remove java 8 incompatible generic signatures

### DIFF
--- a/errai-cdi/errai-cdi-client/src/main/java/org/jboss/errai/enterprise/client/cdi/InstanceProvider.java
+++ b/errai-cdi/errai-cdi-client/src/main/java/org/jboss/errai/enterprise/client/cdi/InstanceProvider.java
@@ -72,16 +72,16 @@ public class InstanceProvider implements ContextualTypeProvider<Instance> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public boolean isUnsatisfied() {
-      Collection<IOCBeanDef<?>> beanDefs = IOC.getBeanManager().lookupBeans(type, qualifiers);
+      Collection beanDefs = IOC.getBeanManager().lookupBeans(type, qualifiers);
       return beanDefs.isEmpty(); 
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public boolean isAmbiguous() {
-      Collection<IOCBeanDef<?>> beanDefs = IOC.getBeanManager().lookupBeans(type, qualifiers);
+      Collection beanDefs = IOC.getBeanManager().lookupBeans(type, qualifiers);
       return beanDefs.size() > 1;
     }
 


### PR DESCRIPTION
The generics removed in this PR are not supported in current Java 8 Gwt compilation.

If interested, the only other things I needed to do for Java 8 was to update javassist to the latest version.