### PR TITLE
Fixed generic array handling in GWTParameterizedType.getTypeParameters.

### DIFF
--- a/errai-codegen-gwt/src/main/java/org/jboss/errai/codegen/meta/impl/gwt/GWTParameterizedType.java
+++ b/errai-codegen-gwt/src/main/java/org/jboss/errai/codegen/meta/impl/gwt/GWTParameterizedType.java
@@ -48,6 +48,11 @@ public class GWTParameterizedType extends AbstractMetaParameterizedType {
       else if (parm.isTypeParameter() != null) {
         types.add(new GWTTypeVariable(oracle, parm.isTypeParameter()));
       }
+      else if (parm.isArray() != null
+              && parm.isArray().getComponentType().isTypeParameter() != null) {
+        // is generic array. Erase to Object[]
+        types.add(GWTClass.newInstance(oracle, parm.isArray().getErasedType()));
+      }
       else if (parm.isClassOrInterface() != null
               || parm.isEnum() != null
               || parm.isPrimitive() != null

--- a/errai-codegen-gwt/src/test/java/org/jboss/errai/codegen/gwt/test/GWTParameterizedTypeTest.java
+++ b/errai-codegen-gwt/src/test/java/org/jboss/errai/codegen/gwt/test/GWTParameterizedTypeTest.java
@@ -1,0 +1,38 @@
+package org.jboss.errai.codegen.gwt.test;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.jboss.errai.codegen.meta.MetaType;
+import org.jboss.errai.codegen.meta.impl.gwt.GWTParameterizedType;
+import org.junit.Test;
+
+import com.google.gwt.core.ext.typeinfo.JClassType;
+import com.google.gwt.core.ext.typeinfo.JType;
+import com.google.gwt.core.ext.typeinfo.TypeOracle;
+
+public class GWTParameterizedTypeTest {
+
+  private static final TypeOracle mockacle;
+  static {
+    MockacleFactory f = new MockacleFactory(new File(
+            "../errai-codegen/src/test/java"));
+    f.addTestClass("org.jboss.errai.codegen.test.model.GenericArrayCollectionTestModel");
+
+    mockacle = f.generateMockacle();
+  }
+
+  @Test
+  public void getTypeParameters_GenericArray() {
+    JClassType type = mockacle
+            .findType("org.jboss.errai.codegen.test.model.GenericArrayCollectionTestModel");
+    JType returnType = type.getMethods()[0].getReturnType();
+    GWTParameterizedType parameterizedType = new GWTParameterizedType(mockacle,
+            returnType.isParameterized());
+    MetaType[] typeParameters = parameterizedType.getTypeParameters();
+    assertEquals(typeParameters.length, 1);
+    assertEquals(typeParameters[0].getName(), "Object[]");
+  }
+
+}

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/GenericArrayCollectionTestModel.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/GenericArrayCollectionTestModel.java
@@ -1,0 +1,10 @@
+package org.jboss.errai.codegen.test.model;
+
+import java.util.List;
+
+public class GenericArrayCollectionTestModel {
+
+  public static <T> List<T[]> getGenericArrays() {
+    return null;
+  }
+}


### PR DESCRIPTION
GWTParameterizedType.getTypeParameters throw IllegalArgumentException
for generic array type parameter.