### PR TITLE
ModuleDef access

### DIFF
--- a/errai-common/src/main/java/org/jboss/errai/common/metadata/RebindUtils.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/metadata/RebindUtils.java
@@ -539,13 +539,7 @@ public class RebindUtils {
   public static Set<String> findTranslatablePackagesInModule(final GeneratorContext context) {
     final Set<String> packages = new HashSet<String>();
     try {
-      final StandardGeneratorContext stdContext = (StandardGeneratorContext) context;
-      final Field field = StandardGeneratorContext.class.getDeclaredField("module");
-      field.setAccessible(true);
-      final Object o = field.get(stdContext);
-
-      final ModuleDef moduleDef = (ModuleDef) o;
-
+      final ModuleDef moduleDef = getModuleDef(context);
       if (moduleDef == null) {
         return Collections.emptySet();
       }
@@ -561,10 +555,6 @@ public class RebindUtils {
           packages.add(packageName);
         }
       }
-    }
-    catch (NoSuchFieldException e) {
-      logger.error("the version of GWT you are running does not appear to be compatible with this version of Errai", e);
-      throw new RuntimeException("could not access the module field in the GeneratorContext");
     }
     catch (Exception e) {
       throw new RuntimeException("could not determine module package", e);


### PR DESCRIPTION
Fixed by calling getModuleDef() in findTranslatablePackagesInModule(), occurs only in special JUnit test case.
