### PR TITLE
Errai 3.2.2.Final  Keycloak 1.7.Final  issue - KC roles not obtained

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-annotation-processors/pom.xml
+++ b/errai-annotation-processors/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>errai-annotation-processors</artifactId>
   <name>Errai::Annotation Checkers</name>

--- a/errai-annotation-processors/pom.xml
+++ b/errai-annotation-processors/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <artifactId>errai-annotation-processors</artifactId>
   <name>Errai::Annotation Checkers</name>

--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -285,12 +285,29 @@
         <groupId>org.lesscss</groupId>
         <artifactId>lesscss</artifactId>
         <version>${lesscss.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>org.apache.stanbol</groupId>
         <artifactId>org.apache.stanbol.enhancer.engines.htmlextractor</artifactId>
-        <version>${apache.stanbol.htmlextractor.version}</version>      
+        <version>${apache.stanbol.htmlextractor.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${version.org.apache.httpcomponents.httpclient}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.jboss.errai.bom</groupId>
   <artifactId>errai-bom</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>pom</packaging>
   <name>JBoss Errai BOM</name>
 

--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.jboss.errai.bom</groupId>
   <artifactId>errai-bom</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>JBoss Errai BOM</name>
 

--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -88,7 +88,7 @@
     <jetty.version>6.1.25</jetty.version>
     <jsoup.version>1.7.1</jsoup.version>
     <jsr305.version>1.3.9</jsr305.version>
-    <keycloak.version>1.2.0.Final</keycloak.version>
+    <keycloak.version>1.7.0.Final</keycloak.version>
     <lesscss.version>1.3.3</lesscss.version>    
     <mockito.core.version>1.9.5</mockito.core.version>
     <mojo.executor.version>2.2.0</mojo.executor.version>

--- a/errai-bus-websocket/errai-bus-jboss7-websocket/pom.xml
+++ b/errai-bus-websocket/errai-bus-jboss7-websocket/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-bus-websocket-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-bus-websocket/errai-bus-jboss7-websocket/pom.xml
+++ b/errai-bus-websocket/errai-bus-jboss7-websocket/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-bus-websocket-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-bus-websocket/errai-bus-jsr356-websocket-weld/pom.xml
+++ b/errai-bus-websocket/errai-bus-jsr356-websocket-weld/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-bus-websocket-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-bus-websocket/errai-bus-jsr356-websocket-weld/pom.xml
+++ b/errai-bus-websocket/errai-bus-jsr356-websocket-weld/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-bus-websocket-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-bus-websocket/errai-bus-jsr356-websocket/pom.xml
+++ b/errai-bus-websocket/errai-bus-jsr356-websocket/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-bus-websocket-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-bus-websocket/errai-bus-jsr356-websocket/pom.xml
+++ b/errai-bus-websocket/errai-bus-jsr356-websocket/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-bus-websocket-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-bus-websocket/pom.xml
+++ b/errai-bus-websocket/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/errai-bus-websocket/pom.xml
+++ b/errai-bus-websocket/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/errai-bus/pom.xml
+++ b/errai-bus/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-bus/pom.xml
+++ b/errai-bus/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-bus/src/main/java/org/jboss/errai/bus/rebind/RpcProxyLoaderGenerator.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/rebind/RpcProxyLoaderGenerator.java
@@ -16,6 +16,7 @@
 
 package org.jboss.errai.bus.rebind;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 
 import org.jboss.errai.bus.client.api.messaging.MessageBus;
@@ -48,7 +49,7 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 
 /**
  * Generates the implementation of {@link RpcProxyLoader}.
- * 
+ *
  * @author Christian Sadilek <csadilek@redhat.com>
  */
 @GenerateAsync(RpcProxyLoader.class)
@@ -67,7 +68,7 @@ public class RpcProxyLoaderGenerator extends AbstractAsyncGenerator {
   @Override
   protected String generate(final TreeLogger logger, final GeneratorContext context) {
     log.info("generating RPC proxy loader class...");
-    
+
     ClassStructureBuilder<?> classBuilder = ClassBuilder.implement(RpcProxyLoader.class);
     final long time = System.currentTimeMillis();
     final MethodBlockBuilder<?> loadProxies =
@@ -76,7 +77,7 @@ public class RpcProxyLoaderGenerator extends AbstractAsyncGenerator {
     final Collection<MetaClass> remotes = ClassScanner.getTypesAnnotatedWith(Remote.class,
         RebindUtils.findTranslatablePackages(context), context);
     addCacheRelevantClasses(remotes);
-    
+
     final InterceptorProvider interceptorProvider = getInterceptorProvider(context);
 
     for (final MetaClass remote : remotes) {
@@ -109,20 +110,26 @@ public class RpcProxyLoaderGenerator extends AbstractAsyncGenerator {
     final Collection<MetaClass> featureInterceptors = ClassScanner.getTypesAnnotatedWith(FeatureInterceptor.class,
         RebindUtils.findTranslatablePackages(context), context);
     addCacheRelevantClasses(featureInterceptors);
-    
+
     final Collection<MetaClass> standaloneInterceptors = ClassScanner.getTypesAnnotatedWith(InterceptsRemoteCall.class,
         RebindUtils.findTranslatablePackages(context), context);
     addCacheRelevantClasses(standaloneInterceptors);
-    
+
     return new InterceptorProvider(featureInterceptors, standaloneInterceptors);
   }
 
   @Override
   protected boolean isRelevantClass(MetaClass clazz) {
-    return clazz.isAnnotationPresent(Remote.class) || clazz.isAnnotationPresent(FeatureInterceptor.class)
-            || clazz.isAnnotationPresent(InterceptsRemoteCall.class); 
+    for (final Annotation anno : clazz.getAnnotations()) {
+      if (anno.annotationType().equals(Remote.class) || anno.annotationType().equals(FeatureInterceptor.class)
+              || anno.annotationType().equals(InterceptsRemoteCall.class)) {
+        return true;
+      }
+    }
+
+    return false;
   }
-  
-  
+
+
 
 }

--- a/errai-bus/src/main/java/org/jboss/errai/bus/rebind/RpcProxyLoaderGenerator.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/rebind/RpcProxyLoaderGenerator.java
@@ -118,7 +118,7 @@ public class RpcProxyLoaderGenerator extends AbstractAsyncGenerator {
   }
 
   @Override
-  protected boolean isRelevantNewClass(MetaClass clazz) {
+  protected boolean isRelevantClass(MetaClass clazz) {
     return clazz.isAnnotationPresent(Remote.class) || clazz.isAnnotationPresent(FeatureInterceptor.class)
             || clazz.isAnnotationPresent(InterceptsRemoteCall.class); 
   }

--- a/errai-cdi-async-databinding-tests/pom.xml
+++ b/errai-cdi-async-databinding-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-cdi-async-databinding-tests/pom.xml
+++ b/errai-cdi-async-databinding-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-cdi-async-tests/pom.xml
+++ b/errai-cdi-async-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-cdi-async-tests/pom.xml
+++ b/errai-cdi-async-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-cdi/errai-cdi-client/pom.xml
+++ b/errai-cdi/errai-cdi-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>cdi-integration-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-cdi/errai-cdi-client/pom.xml
+++ b/errai-cdi/errai-cdi-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>cdi-integration-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-cdi/jboss/pom.xml
+++ b/errai-cdi/jboss/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>cdi-integration-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-cdi/jboss/pom.xml
+++ b/errai-cdi/jboss/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>cdi-integration-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
@@ -1,9 +1,8 @@
 package org.jboss.errai.cdi.server.gwt;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.BindException;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
@@ -57,8 +56,10 @@ public class EmbeddedWildFlyLauncher extends ServletContainerLauncher {
   
   private static final String ERRAI_PROPERTIES_HINT_START = "#Errai-Start\n";
   private static final String ERRAI_PROPERTIES_HINT_END = "\n#Errai-End\n";
-          
-  static { 
+  private static final String ERRAI_PROPERTIES_REALM_TOKEN = "\n#$REALM_NAME=ApplicationRealm$ This line is used by " +
+          "the add-user utility to identify the realm name already used in this file.\n";
+
+  static {
     System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
   }
   
@@ -98,37 +99,68 @@ public class EmbeddedWildFlyLauncher extends ServletContainerLauncher {
             Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.USERS_PROPERTY_FILE);
     
     if (usersStream != null) {
-      writeConfigurationPropertyFile(JBossUtil.USERS_PROPERTY_FILE, jbossHome, usersStream);
+      processPropertiesFile(JBossUtil.USERS_PROPERTY_FILE, jbossHome, usersStream, true);
     }
     
     InputStream rolesStream = 
             Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.ROLES_PROPERTY_FILE);
     
     if (rolesStream != null) {
-      writeConfigurationPropertyFile(JBossUtil.ROLES_PROPERTY_FILE, jbossHome, rolesStream);
+      processPropertiesFile(JBossUtil.ROLES_PROPERTY_FILE, jbossHome, rolesStream, false);
     }
   }
-  
-  private void writeConfigurationPropertyFile(final String propertyFileName, final String jbossHome, final InputStream in) {
+
+  private void processPropertiesFile(final String propertyFileName, final String jbossHome,
+                                           final InputStream newUsersStream, final boolean handleRealmToken) {
     final File propertyDir = new File(jbossHome, JBossUtil.STANDALONE_CONFIGURATION);
     final File propertyFile = new File(propertyDir, propertyFileName);
+
     try {
-      String content = FileUtils.readFileToString(propertyFile);
-      String erraiContent = StringUtils.substringBetween(content, ERRAI_PROPERTIES_HINT_START, ERRAI_PROPERTIES_HINT_END);
-      
-      content = content.replace(ERRAI_PROPERTIES_HINT_START, "");
-      if (erraiContent != null) {
-        content = content.replace(erraiContent, "");
+
+      String realmToken = ERRAI_PROPERTIES_REALM_TOKEN;
+      boolean isErraiContent = false;
+      final StringBuilder result = new StringBuilder();
+      List<String> lines = FileUtils.readLines(propertyFile);
+      if (lines != null) {
+
+        for (final String currentLine : lines) {
+          String trimmed = currentLine.trim();
+          if(trimmed.startsWith(ERRAI_PROPERTIES_HINT_START.trim())) {
+            isErraiContent = true;
+          } else if(trimmed.startsWith(ERRAI_PROPERTIES_HINT_END.trim())) {
+            isErraiContent = false;
+          } else if(handleRealmToken && trimmed.startsWith("#") && trimmed.contains("$REALM_NAME=")) {
+            realmToken = currentLine;
+          } else if (!isErraiContent) {
+            result.append(currentLine).append("\n");
+          }
+        }
+
+        final String newUsersStr = IOUtils.toString(newUsersStream, (String) null);
+        result.append(ERRAI_PROPERTIES_HINT_START);
+        result.append(newUsersStr).append("\n");
+        result.append(ERRAI_PROPERTIES_HINT_END);
+
+        if (handleRealmToken) {
+          result.append(realmToken).append("\n");
+        }
+
+        try {
+          FileUtils.write(propertyFile, result.toString());
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to write content for " +
+                  propertyFileName + " in " + propertyFile.getAbsolutePath(), e);
+        }
       }
-      content = content.replace(ERRAI_PROPERTIES_HINT_END, "");
-      content += ERRAI_PROPERTIES_HINT_START + IOUtils.toString(in, (String) null) + ERRAI_PROPERTIES_HINT_END;
-      FileUtils.write(propertyFile, content);
-    } 
-    catch (IOException e) {
-      throw new RuntimeException("Failed to write " + 
-              JBossUtil.USERS_PROPERTY_FILE + " in " + propertyFile.getAbsolutePath());
+
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to parse content for " +
+              propertyFileName + " in " + propertyFile.getAbsolutePath(), e);
     }
+
   }
+
+
 
   /**
    * Writes a new or updates an existing beans.xml file to add exclusions for

--- a/errai-cdi/pom.xml
+++ b/errai-cdi/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-cdi/pom.xml
+++ b/errai-cdi/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-cdi/weld-integration/pom.xml
+++ b/errai-cdi/weld-integration/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>cdi-integration-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-cdi/weld-integration/pom.xml
+++ b/errai-cdi/weld-integration/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>cdi-integration-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-cdi/weld-integration/src/main/java/org/jboss/errai/cdi/server/CDIExtensionPoints.java
+++ b/errai-cdi/weld-integration/src/main/java/org/jboss/errai/cdi/server/CDIExtensionPoints.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Extension points to the CDI container. Makes Errai components available as CDI beans (i.e. the
  * message bus) and registers CDI components as services with Errai.
- * 
+ *
  * @author Heiko Braun <hbraun@redhat.com>
  * @author Mike Brock <cbrock@redhat.com>
  * @author Christian Sadilek <csadilek@redhat.com>
@@ -148,7 +148,7 @@ public class CDIExtensionPoints implements Extension {
 
   /**
    * Register managed beans as Errai services
-   * 
+   *
    * @param event
    *          -
    * @param <T>
@@ -265,9 +265,9 @@ public class CDIExtensionPoints implements Extension {
     subscribeServices(bm, bus);
 
     // initialize the CDI event bridge to the client
-    final EventDispatcher eventDispatcher = 
+    final EventDispatcher eventDispatcher =
             new EventDispatcher(bm, eventRoutingTable, bus, observableEvents, eventQualifiers);
-    
+
     AnyEventObserver.init(eventDispatcher);
 
     // subscribe event dispatcher
@@ -293,21 +293,21 @@ public class CDIExtensionPoints implements Extension {
 
       this.expiryTime = System.currentTimeMillis() + (timeOutInSeconds * 1000);
     }
-    
+
     private Annotation[] getQualifiers(Class<?> delegateClass) {
       int length = 0;
       for (Annotation anno : delegateClass.getAnnotations()) {
         if (anno.annotationType().isAnnotationPresent(Qualifier.class))
           length += 1;
       }
-      
+
       Annotation[] ret = new Annotation[length];
       int i = 0;
       for (Annotation anno : delegateClass.getAnnotations()) {
         if (anno.annotationType().isAnnotationPresent(Qualifier.class))
           ret[i++] = anno;
       }
-      
+
       return ret;
     }
 
@@ -329,16 +329,16 @@ public class CDIExtensionPoints implements Extension {
           if (!toRegister.contains(delegateClass) || beanManager.getBeans(delegateClass, getQualifiers(delegateClass)).size() == 0) {
             continue;
           }
-        } 
+        }
         catch(Throwable t) {
           continue;
         }
-        
+
         for (final ServiceParser svcParser : managedTypes.getDelegateServices(delegateClass)) {
           final Object delegateInstance;
           try {
             delegateInstance = CDIServerUtil.lookupBean(beanManager, delegateClass, getQualifiers(delegateClass));
-          } 
+          }
           catch (IllegalStateException t) {
             // handle WELD-001332: BeanManager method getReference() is not available during application initialization
             // try again later...

--- a/errai-client-local-class-hider/pom.xml
+++ b/errai-client-local-class-hider/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-client-local-class-hider/pom.xml
+++ b/errai-client-local-class-hider/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-codegen-gwt/pom.xml
+++ b/errai-codegen-gwt/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-codegen-gwt/pom.xml
+++ b/errai-codegen-gwt/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-codegen/pom.xml
+++ b/errai-codegen/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Errai::Codegen</name>

--- a/errai-codegen/pom.xml
+++ b/errai-codegen/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Errai::Codegen</name>

--- a/errai-codegen/src/main/java/org/jboss/errai/codegen/meta/impl/AbstractMetaClass.java
+++ b/errai-codegen/src/main/java/org/jboss/errai/codegen/meta/impl/AbstractMetaClass.java
@@ -468,13 +468,13 @@ public abstract class AbstractMetaClass<T> extends MetaClass {
 
     final MetaClass sup;
 
-    if (MetaClassFactory.get(Object.class).equals(this)) {
+    if (getFullyQualifiedName().equals(Object.class.getName())) {
       assignable = true;
     }
     else if (this.getFullyQualifiedName().equals(clazz.getFullyQualifiedName())) {
       assignable = true;
     }
-    else if (_hasInterface(clazz.getInterfaces(), this.getErased())) {
+    else if (isInterface() && _hasInterface(clazz.getInterfaces(), this.getErased())) {
       assignable = true;
     }
     else

--- a/errai-codegen/src/main/java/org/jboss/errai/codegen/meta/impl/java/JavaReflectionClass.java
+++ b/errai-codegen/src/main/java/org/jboss/errai/codegen/meta/impl/java/JavaReflectionClass.java
@@ -176,7 +176,7 @@ public class JavaReflectionClass extends AbstractMetaClass<Class> {
       for (final Method method : type.getDeclaredMethods()) {
         JavaReflectionMethod metaMethod = new JavaReflectionMethod(this, method);
         String readableMethodDecl = GenUtil.getMethodString(metaMethod);
-        if (!metaMethod.isPrivate() && !processedMethods.contains(readableMethodDecl)) {
+        if (!metaMethod.isPrivate() && !method.isBridge() && !processedMethods.contains(readableMethodDecl)) {
             meths.add(metaMethod);
             processedMethods.add(readableMethodDecl);
         }

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/meta/AbstractMetaClassTest.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/meta/AbstractMetaClassTest.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.codegen.meta.MetaField;
 import org.jboss.errai.codegen.meta.MetaMethod;
@@ -57,6 +56,7 @@ import org.jboss.errai.codegen.util.GenUtil;
 import org.junit.Test;
 import org.mvel2.util.NullType;
 
+import com.google.common.collect.Lists;
 import com.google.gwt.core.ext.typeinfo.NotFoundException;
 
 /**
@@ -550,7 +550,7 @@ public abstract class AbstractMetaClassTest {
             Arrays.asList(getMetaClass(Serializable.class)),
             Arrays.asList(returnType.getBounds()));
   }
-  
+
   @Test
   public void testFieldWithTwoUpperBoundedTypeVarParam() throws Exception {
     final MetaClass metaClass = getMetaClass(ClassWithGenericCollections.class);
@@ -663,14 +663,14 @@ public abstract class AbstractMetaClassTest {
     assertArrayEquals(new MetaType[] { getMetaClass(String.class) }, typeParam.getLowerBounds());
     assertArrayEquals(new MetaType[] { getMetaClass(Object.class)}, typeParam.getUpperBounds());
   }
-  
+
   @Test
   public void testGetMethods() {
     final MetaClass c = getMetaClass(Child.class);
     MetaMethod[] methods = c.getMethods();
-    
+
     assertNotNull(methods);
-    
+
     List<String> methodSignatures = new ArrayList<String>();
     for(MetaMethod m : methods) {
       methodSignatures.add(GenUtil.getMethodString(m));
@@ -691,10 +691,10 @@ public abstract class AbstractMetaClassTest {
     expectedMethods.add("wait([long])");
     expectedMethods.add("hashCode([])");
     expectedMethods.add("wait([long, int])");
-    
+
     Collections.sort(expectedMethods);
     Collections.sort(methodSignatures);
-    
+
 
     assertEquals(expectedMethods.toString(), methodSignatures.toString());
   }

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/meta/java/JavaReflectionMetaClassTest.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/meta/java/JavaReflectionMetaClassTest.java
@@ -1,8 +1,16 @@
 package org.jboss.errai.codegen.test.meta.java;
 
+import static org.jboss.errai.codegen.util.Stmt.nestedCall;
+import static org.jboss.errai.codegen.util.Stmt.newObject;
+import static org.junit.Assert.assertEquals;
+
+import org.jboss.errai.codegen.builder.ContextualStatementBuilder;
 import org.jboss.errai.codegen.meta.MetaClass;
+import org.jboss.errai.codegen.meta.MetaMethod;
 import org.jboss.errai.codegen.meta.impl.java.JavaReflectionClass;
 import org.jboss.errai.codegen.test.meta.AbstractMetaClassTest;
+import org.jboss.errai.codegen.test.model.PortableIntegerParameterDefinition;
+import org.junit.Test;
 
 public class JavaReflectionMetaClassTest extends AbstractMetaClassTest {
 
@@ -14,6 +22,29 @@ public class JavaReflectionMetaClassTest extends AbstractMetaClassTest {
   @Override
   protected Class<? extends MetaClass> getTypeOfMetaClassBeingTested() {
     return JavaReflectionClass.class;
+  }
+
+  /**
+   * This reproduces a bug found in the JavaReflectionClass.
+   * PortableIntegerParameterDefinition overrides a method with a generic return
+   * type (getValue). Class.getDeclaredMethods returns a bridge method with a
+   * return type of the upper type bound (in this case, Serializable). This
+   * resulted in JavaReflectionClass.getMethods() returning a MetaMethod for
+   * bridge method with the wrong return type, leading to seemingly mysterious
+   * codegen errors.
+   */
+  @Test
+  public void testMethodReturnTypeIsSpecializedTypeAndNotFromBridgeMethod() throws Exception {
+    final MetaClass mc = getMetaClassImpl(PortableIntegerParameterDefinition.class);
+    final MetaMethod method = mc.getBestMatchingMethod("getValue", new MetaClass[0]);
+    final ContextualStatementBuilder invokeStmt = nestedCall(newObject(mc)).invoke("getValue");
+    // Force statement to load return type
+    invokeStmt.toJavaString();
+    final MetaClass stmtReturnType = invokeStmt.getType();
+
+    final MetaClass expected = getMetaClassImpl(java.lang.Integer.class);
+    assertEquals(expected, method.getReturnType());
+    assertEquals(expected, stmtReturnType);
   }
 
 }

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/HasBinding.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/HasBinding.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.codegen.test.model;
+
+/**
+ * Implementations can be bound to a variable
+ */
+public interface HasBinding {
+
+    String getBinding();
+
+    void setBinding( String binding );
+
+    boolean isBound();
+
+}

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/HasValue.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/HasValue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.codegen.test.model;
+
+import java.io.Serializable;
+
+public interface HasValue<T extends Serializable> {
+
+  T getValue();
+
+  void setValue( T value );
+
+}

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/PortableIntegerParameterDefinition.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/PortableIntegerParameterDefinition.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.codegen.test.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+
+/**
+ * An Integer parameter
+ */
+@Portable
+public class PortableIntegerParameterDefinition
+        extends PortableParameterDefinition
+        implements HasValue<java.lang.Integer>,
+                   HasBinding {
+
+    private String binding;
+
+    private java.lang.Integer value;
+
+    public PortableIntegerParameterDefinition() {
+
+    }
+
+    @Override
+    public java.lang.Integer getValue() {
+        return this.value;
+    }
+
+    @Override
+    public void setValue( java.lang.Integer value ) {
+        this.value = value;
+    }
+
+    @Override
+    public String getBinding() {
+        return this.binding;
+    }
+
+    @Override
+    public void setBinding( String binding ) {
+        this.binding = binding;
+    }
+
+    @Override
+    public String asString() {
+        if ( isBound() ) {
+            return this.getBinding();
+        }
+        if ( this.value == null ) {
+            return "null";
+        }
+        return java.lang.Integer.toString( this.value );
+    }
+
+    @Override
+    public String getClassName() {
+        return Integer.class.getName();
+    }
+
+    @Override
+    public boolean isBound() {
+        return ( this.getBinding() != null && !"".equals( this.getBinding() ) );
+    }
+
+}

--- a/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/PortableParameterDefinition.java
+++ b/errai-codegen/src/test/java/org/jboss/errai/codegen/test/model/PortableParameterDefinition.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.errai.codegen.test.model;
+
+/**
+ * A ParameterDefinition used in Guvnor.
+ * @see org.drools.core.process.core.ParameterDefinition
+ */
+public abstract class PortableParameterDefinition {
+
+    private String name;
+
+    public PortableParameterDefinition() {
+    }
+
+    public PortableParameterDefinition( String name ) {
+        setName( name );
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName( String name ) {
+        if ( name == null ) {
+            throw new IllegalArgumentException( "Name cannot be null" );
+        }
+        this.name = name;
+    }
+
+    public abstract String asString();
+
+    public abstract String getClassName();
+
+    public String getSimpleClassName() {
+        String className = getClassName();
+        if ( className == null ) {
+            return null;
+        }
+        int index = className.lastIndexOf( "." );
+        if ( index >= 0 ) {
+            className = className.substring( index + 1 );
+        }
+        return className;
+    }
+
+}

--- a/errai-common/pom.xml
+++ b/errai-common/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-common/pom.xml
+++ b/errai-common/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-config/pom.xml
+++ b/errai-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/errai-config/pom.xml
+++ b/errai-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/errai-config/src/main/java/org/jboss/errai/config/rebind/AbstractAsyncGenerator.java
+++ b/errai-config/src/main/java/org/jboss/errai/config/rebind/AbstractAsyncGenerator.java
@@ -77,7 +77,11 @@ public abstract class AbstractAsyncGenerator extends Generator implements AsyncC
    * @return True iff there is a cached output for this generator. Useful for subclasses that must override {@link #isCacheValid()}.
    */
   protected final boolean hasGenerationCache() {
-    return cacheMap.containsKey(getClass());
+    final boolean hasCache = cacheMap.containsKey(getClass());
+    if (log.isDebugEnabled()) {
+      log.debug("{} {} a generated cache.", getClass().getSimpleName(), (hasCache ? "has" : "does not have"));
+    }
+    return hasCache;
   }
 
   protected final String getGeneratedCache() {
@@ -92,26 +96,34 @@ public abstract class AbstractAsyncGenerator extends Generator implements AsyncC
    * @return True iff this generator does not need to be run again this refresh.
    */
   protected boolean isCacheValid() {
-    boolean hasChanges = MetaClassFactory.hasAnyChanges() && hasRelevantChanges();
-    return hasGenerationCache() && !hasChanges;
+    return hasGenerationCache() && !(MetaClassFactory.hasAnyChanges() && hasRelevantChanges());
   }
   
   private boolean hasRelevantChanges() {
-    Set<String> relevantClasses = cacheRelevantClasses.get(this.getClass());
+    final String generatorName = this.getClass().getSimpleName();
+    final Set<String> relevantClasses = cacheRelevantClasses.get(this.getClass());
     if (relevantClasses == null) {
-      // generator did not mark any classes. we have to assume that a rerun is required.
+      log.debug("No classes marked as relevant for {}. Assuming there are relevant changes.", generatorName);
       return true;
     }
-    
-    for (MetaClass newClazz : MetaClassFactory.getNewClasses()) {
-      if (isRelevantNewClass(newClazz)) {
+
+    for (final MetaClass clazz : MetaClassFactory.getAllNewOrUpdatedClasses()) {
+      final boolean previouslyMarkedRelevant = relevantClasses.contains(clazz.getFullyQualifiedName());
+      if (previouslyMarkedRelevant || isRelevantClass(clazz)) {
+        log.debug("New or updated class {} is {} cache relevant for {}.", clazz.getFullyQualifiedName(),
+                (previouslyMarkedRelevant ? "previously marked as" : "now marked as"), generatorName);
         return true;
+      } else {
+        log.trace("New or updated class {} is not cache relevant for {}.", clazz.getFullyQualifiedName(), generatorName);
       }
     }
-    
-    for (String relevantClass : relevantClasses) {
-      if (MetaClassFactory.isChangedOrDeleted(relevantClass)) {
+
+    for (final String deleted : MetaClassFactory.getAllDeletedClasses()) {
+      if (relevantClasses.contains(deleted)) {
+        log.debug("Deleted class {} was cache relevant for {}.", deleted, generatorName);
         return true;
+      } else {
+        log.trace("Deleted class {} is not cache relevant for {}.", deleted, generatorName);
       }
     }
     
@@ -129,7 +141,7 @@ public abstract class AbstractAsyncGenerator extends Generator implements AsyncC
    * @return true if newly introduced class is relevant to this generator,
    *         otherwise false.
    */
-  protected boolean isRelevantNewClass(MetaClass clazz) {
+  protected boolean isRelevantClass(MetaClass clazz) {
     return true;
   }
 

--- a/errai-cordova-maven-plugin/pom.xml
+++ b/errai-cordova-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/errai-cordova-maven-plugin/pom.xml
+++ b/errai-cordova-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/errai-cordova/pom.xml
+++ b/errai-cordova/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-cordova/pom.xml
+++ b/errai-cordova/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-data-binding/pom.xml
+++ b/errai-data-binding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-data-binding/pom.xml
+++ b/errai-data-binding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/BindableProxyLoaderGenerator.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/BindableProxyLoaderGenerator.java
@@ -150,7 +150,7 @@ public class BindableProxyLoaderGenerator extends AbstractAsyncGenerator {
   }
   
   @Override
-  protected boolean isRelevantNewClass(MetaClass clazz) {
+  protected boolean isRelevantClass(MetaClass clazz) {
     return clazz.isAnnotationPresent(Bindable.class) || clazz.isAnnotationPresent(DefaultConverter.class);
   }
 }

--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/BindableProxyLoaderGenerator.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/BindableProxyLoaderGenerator.java
@@ -16,6 +16,7 @@
 
 package org.jboss.errai.databinding.rebind;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Set;
 
@@ -54,7 +55,7 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 
 /**
  * Generates the proxy loader for {@link Bindable}s.
- * 
+ *
  * @author Christian Sadilek <csadilek@redhat.com>
  */
 @GenerateAsync(BindableProxyLoader.class)
@@ -77,7 +78,7 @@ public class BindableProxyLoaderGenerator extends AbstractAsyncGenerator {
 
     Set<MetaClass> allBindableTypes = DataBindingUtil.getAllBindableTypes(context);
     addCacheRelevantClasses(allBindableTypes);
-    
+
     for (MetaClass bindable : allBindableTypes) {
       if (bindable.isFinal()) {
         throw new RuntimeException("@Bindable type cannot be final: " + bindable.getFullyQualifiedName());
@@ -148,9 +149,15 @@ public class BindableProxyLoaderGenerator extends AbstractAsyncGenerator {
       }
     }
   }
-  
+
   @Override
   protected boolean isRelevantClass(MetaClass clazz) {
-    return clazz.isAnnotationPresent(Bindable.class) || clazz.isAnnotationPresent(DefaultConverter.class);
+    for (final Annotation anno : clazz.getAnnotations()) {
+      if (anno.annotationType().equals(Bindable.class) || anno.annotationType().equals(DefaultConverter.class)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/errai-demos/errai-bus-demo-stock/pom.xml
+++ b/errai-demos/errai-bus-demo-stock/pom.xml
@@ -4,7 +4,7 @@
   <name>Errai::Bus::Demos::Stock</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-bus-demo-stock</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-bus-demo-stock/pom.xml
+++ b/errai-demos/errai-bus-demo-stock/pom.xml
@@ -4,7 +4,7 @@
   <name>Errai::Bus::Demos::Stock</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-bus-demo-stock</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-bus-demo-stress-test/pom.xml
+++ b/errai-demos/errai-bus-demo-stress-test/pom.xml
@@ -5,7 +5,7 @@
   <name>Errai::Bus::Demos::StressTest</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-bus-demo-stress-test</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-bus-demo-stress-test/pom.xml
+++ b/errai-demos/errai-bus-demo-stress-test/pom.xml
@@ -5,7 +5,7 @@
   <name>Errai::Bus::Demos::StressTest</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-bus-demo-stress-test</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-cdi-demo-mobile/pom.xml
+++ b/errai-demos/errai-cdi-demo-mobile/pom.xml
@@ -5,7 +5,7 @@
   <name>Errai::CDI::Demos::Mobile</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-cdi-demo-mobile</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-cdi-demo-mobile/pom.xml
+++ b/errai-demos/errai-cdi-demo-mobile/pom.xml
@@ -5,7 +5,7 @@
   <name>Errai::CDI::Demos::Mobile</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-cdi-demo-mobile</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-cdi-demo-mvp/pom.xml
+++ b/errai-demos/errai-cdi-demo-mvp/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.jboss.errai.demos</groupId>
   <name>Errai::CDI::Demos::MVP</name>
   <artifactId>errai-cdi-demo-mvp</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-cdi-demo-mvp/pom.xml
+++ b/errai-demos/errai-cdi-demo-mvp/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.jboss.errai.demos</groupId>
   <name>Errai::CDI::Demos::MVP</name>
   <artifactId>errai-cdi-demo-mvp</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-cdi-demo-tagcloud/pom.xml
+++ b/errai-demos/errai-cdi-demo-tagcloud/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-cdi-demo-tagcloud</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>Errai::CDI::Demos::TagCloud</name>
 

--- a/errai-demos/errai-cdi-demo-tagcloud/pom.xml
+++ b/errai-demos/errai-cdi-demo-tagcloud/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-cdi-demo-tagcloud</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
   <name>Errai::CDI::Demos::TagCloud</name>
 

--- a/errai-demos/errai-jaxrs-demo-crud/pom.xml
+++ b/errai-demos/errai-jaxrs-demo-crud/pom.xml
@@ -4,7 +4,7 @@
   <name>Errai::JAX-RS::RestDemo</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-jaxrs-demo-crud</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-jaxrs-demo-crud/pom.xml
+++ b/errai-demos/errai-jaxrs-demo-crud/pom.xml
@@ -4,7 +4,7 @@
   <name>Errai::JAX-RS::RestDemo</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-jaxrs-demo-crud</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-jpa-demo-basic/pom.xml
+++ b/errai-demos/errai-jpa-demo-basic/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.jboss.errai.demos</groupId>
   <name>Errai::JPA::Demos::Basic</name>
   <artifactId>errai-jpa-demo-basic</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-jpa-demo-basic/pom.xml
+++ b/errai-demos/errai-jpa-demo-basic/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.jboss.errai.demos</groupId>
   <name>Errai::JPA::Demos::Basic</name>
   <artifactId>errai-jpa-demo-basic</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-jpa-demo-grocery-list/pom.xml
+++ b/errai-demos/errai-jpa-demo-grocery-list/pom.xml
@@ -5,7 +5,7 @@
   <name>Errai::JPA::Demos::GroceryList</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-jpa-demo-grocery-list</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-jpa-demo-grocery-list/pom.xml
+++ b/errai-demos/errai-jpa-demo-grocery-list/pom.xml
@@ -5,7 +5,7 @@
   <name>Errai::JPA::Demos::GroceryList</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-jpa-demo-grocery-list</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-jpa-demo-todo-list/pom.xml
+++ b/errai-demos/errai-jpa-demo-todo-list/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-jpa-demo-todo-list</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
 
   <packaging>war</packaging>
   <name>Errai::JPA::Demos::ToDoList</name>

--- a/errai-demos/errai-jpa-demo-todo-list/pom.xml
+++ b/errai-demos/errai-jpa-demo-todo-list/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-jpa-demo-todo-list</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
 
   <packaging>war</packaging>
   <name>Errai::JPA::Demos::ToDoList</name>

--- a/errai-demos/errai-security-demo/pom.xml
+++ b/errai-demos/errai-security-demo/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai</groupId>
   <artifactId>errai-security-demo</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>Errai Security::Demo</name>
 

--- a/errai-demos/errai-security-demo/pom.xml
+++ b/errai-demos/errai-security-demo/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai</groupId>
   <artifactId>errai-security-demo</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
   <name>Errai Security::Demo</name>
 

--- a/errai-demos/errai-ui-demo-i18n/pom.xml
+++ b/errai-demos/errai-ui-demo-i18n/pom.xml
@@ -4,7 +4,7 @@
   <name>Errai::UI::Demos::I18NDemo</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-ui-demos-i18ndemo</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/errai-ui-demo-i18n/pom.xml
+++ b/errai-demos/errai-ui-demo-i18n/pom.xml
@@ -4,7 +4,7 @@
   <name>Errai::UI::Demos::I18NDemo</name>
   <groupId>org.jboss.errai.demos</groupId>
   <artifactId>errai-ui-demos-i18ndemo</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/errai-demos/pom.xml
+++ b/errai-demos/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>errai-demos</artifactId>

--- a/errai-demos/pom.xml
+++ b/errai-demos/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
 
   <artifactId>errai-demos</artifactId>

--- a/errai-docs/pom.xml
+++ b/errai-docs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-docs/pom.xml
+++ b/errai-docs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-docs/src/main/docbook/en/reference.xml
+++ b/errai-docs/src/main/docbook/en/reference.xml
@@ -9,7 +9,7 @@
     <title>Errai Reference Guide</title>
     
     
-    <date>2015-10-27</date>
+    <date>2016-01-12</date>
     
     
     

--- a/errai-forge-addon/pom.xml
+++ b/errai-forge-addon/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai.forge</groupId>
   <artifactId>errai-forge-addon</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
 
   <name>Errai::Forge Addon</name>
   <properties>

--- a/errai-forge-addon/pom.xml
+++ b/errai-forge-addon/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai.forge</groupId>
   <artifactId>errai-forge-addon</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
 
   <name>Errai::Forge Addon</name>
   <properties>

--- a/errai-forge-addon/src/main/java/org/jboss/errai/forge/facet/plugin/DependencyPluginFacet.java
+++ b/errai-forge-addon/src/main/java/org/jboss/errai/forge/facet/plugin/DependencyPluginFacet.java
@@ -53,8 +53,8 @@ public class DependencyPluginFacet extends AbstractPluginFacet {
                                             .setName("type").setText("zip"))
                                     .addChild(ConfigurationElementBuilder.create()
                                             .setName("overWrite").setText("false"))
-//                                    .addChild(ConfigurationElementBuilder.create()
-//                                            .setName("outputDirectory").setText("${project.build.directory}"))
+                                    .addChild(ConfigurationElementBuilder.create()
+                                            .setName("outputDirectory").setText("${project.build.directory}"))
 
                              )
                     )

--- a/errai-forge-addon/src/test/java/org/jboss/errai/forge/test/base/ForgeTest.java
+++ b/errai-forge-addon/src/test/java/org/jboss/errai/forge/test/base/ForgeTest.java
@@ -52,7 +52,7 @@ public abstract class ForgeTest {
   public static final String DEPENDENCY = "org.jboss.errai.forge:errai-forge-addon";
   public static final String ADDON_GROUP = "org.jboss.forge.addon";
   // TODO Programmatically lookup the Errai version this test is running in.
-  public static final String ERRAI_TEST_VERSION = "3.2.0-SNAPSHOT";
+  public static final String ERRAI_TEST_VERSION = "3.2.2-SNAPSHOT";
 
   @Inject
   protected ProjectFactory projectFactory;
@@ -101,7 +101,7 @@ public abstract class ForgeTest {
 
     return project;
   }
-  
+
   protected void assertResourceAndFileContentsSame(final String resourcePath, final File file)
           throws IOException {
     assertTrue(file.getAbsolutePath() + " was not created.", file.exists());
@@ -123,7 +123,7 @@ public abstract class ForgeTest {
         builders[i].append(chars, 0, read);
       }
     }
-    
+
     try {
       assertEquals(builders[0].toString(), builders[1].toString());
     }
@@ -133,7 +133,7 @@ public abstract class ForgeTest {
 
       System.out.println("OBSERVED");
       System.out.println(builders[1].toString());
-      
+
       throw e;
     }
   }
@@ -141,14 +141,14 @@ public abstract class ForgeTest {
   protected Project createErraiTestProject() {
     final Project project = initializeJavaProject();
     final ProjectConfig projectConfig = facetFactory.install(project, ProjectConfig.class);
-  
+
     projectConfig.setProjectProperty(ProjectProperty.ERRAI_VERSION, ERRAI_TEST_VERSION);
     projectConfig.setProjectProperty(ProjectProperty.MODULE_LOGICAL, "org.jboss.errai.ForgeTest");
     projectConfig.setProjectProperty(ProjectProperty.MODULE_FILE, new File(project.getRootDirectory()
             .getUnderlyingResourceObject(), "src/main/java/org/jboss/errai/ForgeTest.gwt.xml"));
     projectConfig.setProjectProperty(ProjectProperty.MODULE_NAME, "test");
     projectConfig.setProjectProperty(ProjectProperty.INSTALLED_FEATURES, new SerializableSet());
-  
+
     return project;
   }
 

--- a/errai-html5/pom.xml
+++ b/errai-html5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <artifactId>errai-parent</artifactId>
       <groupId>org.jboss.errai</groupId>
-      <version>3.2.2-SNAPSHOT</version>
+      <version>3.2.2.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/errai-html5/pom.xml
+++ b/errai-html5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <artifactId>errai-parent</artifactId>
       <groupId>org.jboss.errai</groupId>
-      <version>3.2.1.Final</version>
+      <version>3.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/errai-internal-bom/pom.xml
+++ b/errai-internal-bom/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai.bom</groupId>
   <artifactId>errai-internal-bom</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>pom</packaging>
   <name>Errai Internal BOM (Bill Of Materials)</name>
 

--- a/errai-internal-bom/pom.xml
+++ b/errai-internal-bom/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.errai.bom</groupId>
   <artifactId>errai-internal-bom</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Errai Internal BOM (Bill Of Materials)</name>
 

--- a/errai-ioc-async-tests/pom.xml
+++ b/errai-ioc-async-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-ioc-async-tests/pom.xml
+++ b/errai-ioc-async-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-ioc-bus-support/pom.xml
+++ b/errai-ioc-bus-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-ioc-bus-support/pom.xml
+++ b/errai-ioc-bus-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-ioc/pom.xml
+++ b/errai-ioc/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-ioc/pom.xml
+++ b/errai-ioc/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-javaee-all/pom.xml
+++ b/errai-javaee-all/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>errai-parent</artifactId>
       <groupId>org.jboss.errai</groupId>
-      <version>3.2.2-SNAPSHOT</version>
+      <version>3.2.2.Final</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
 

--- a/errai-javaee-all/pom.xml
+++ b/errai-javaee-all/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>errai-parent</artifactId>
       <groupId>org.jboss.errai</groupId>
-      <version>3.2.1.Final</version>
+      <version>3.2.2-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
 

--- a/errai-javax-enterprise/pom.xml
+++ b/errai-javax-enterprise/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>errai-parent</artifactId>
         <groupId>org.jboss.errai</groupId>
-        <version>3.2.1.Final</version>
+        <version>3.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/errai-javax-enterprise/pom.xml
+++ b/errai-javax-enterprise/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>errai-parent</artifactId>
         <groupId>org.jboss.errai</groupId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>3.2.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/errai-jaxrs/errai-jaxrs-client/pom.xml
+++ b/errai-jaxrs/errai-jaxrs-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>jaxrs-integration-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-jaxrs/errai-jaxrs-client/pom.xml
+++ b/errai-jaxrs/errai-jaxrs-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>jaxrs-integration-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-jaxrs/errai-jaxrs-client/src/main/java/org/jboss/errai/enterprise/rebind/JaxrsProxyLoaderGenerator.java
+++ b/errai-jaxrs/errai-jaxrs-client/src/main/java/org/jboss/errai/enterprise/rebind/JaxrsProxyLoaderGenerator.java
@@ -16,6 +16,7 @@
 
 package org.jboss.errai.enterprise.rebind;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 
 import javax.ws.rs.Path;
@@ -51,7 +52,7 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 
 /**
  * Generates the JAX-RS proxy loader.
- * 
+ *
  * @author Christian Sadilek <csadilek@redhat.com>
  */
 @GenerateAsync(JaxrsProxyLoader.class)
@@ -77,7 +78,7 @@ public class JaxrsProxyLoaderGenerator extends AbstractAsyncGenerator {
     Collection<MetaClass> remotes = ClassScanner.getTypesAnnotatedWith(Path.class,
         RebindUtils.findTranslatablePackages(context), context);
     addCacheRelevantClasses(remotes);
-    
+
     for (MetaClass remote : remotes) {
       if (remote.isInterface()) {
         // create the remote proxy for this interface
@@ -133,7 +134,7 @@ public class JaxrsProxyLoaderGenerator extends AbstractAsyncGenerator {
     for (MetaClass metaClass : providers) {
       if (!metaClass.isAbstract() && metaClass.isAssignableTo(ClientExceptionMapper.class)) {
         MapsFrom mapsFrom = metaClass.getAnnotation(MapsFrom.class);
-        if (mapsFrom == null) { 
+        if (mapsFrom == null) {
           if (genericExceptionMapperClass == null) {
             // Found a generic client-side exception mapper (to be used for all REST interfaces)
             genericExceptionMapperClass = metaClass;
@@ -158,10 +159,16 @@ public class JaxrsProxyLoaderGenerator extends AbstractAsyncGenerator {
 
     return result;
   }
-  
+
   @Override
   protected boolean isRelevantClass(MetaClass clazz) {
-    return clazz.isAnnotationPresent(Path.class) || clazz.isAnnotationPresent(FeatureInterceptor.class)
-            || clazz.isAnnotationPresent(InterceptsRemoteCall.class) || clazz.isAnnotationPresent(Provider.class); 
+    for (final Annotation anno : clazz.getAnnotations()) {
+      if (anno.annotationType().equals(Path.class) || anno.annotationType().equals(FeatureInterceptor.class)
+              || anno.annotationType().equals(InterceptsRemoteCall.class) || anno.annotationType().equals(Provider.class)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/errai-jaxrs/errai-jaxrs-client/src/main/java/org/jboss/errai/enterprise/rebind/JaxrsProxyLoaderGenerator.java
+++ b/errai-jaxrs/errai-jaxrs-client/src/main/java/org/jboss/errai/enterprise/rebind/JaxrsProxyLoaderGenerator.java
@@ -160,7 +160,7 @@ public class JaxrsProxyLoaderGenerator extends AbstractAsyncGenerator {
   }
   
   @Override
-  protected boolean isRelevantNewClass(MetaClass clazz) {
+  protected boolean isRelevantClass(MetaClass clazz) {
     return clazz.isAnnotationPresent(Path.class) || clazz.isAnnotationPresent(FeatureInterceptor.class)
             || clazz.isAnnotationPresent(InterceptsRemoteCall.class) || clazz.isAnnotationPresent(Provider.class); 
   }

--- a/errai-jaxrs/errai-jaxrs-provider/pom.xml
+++ b/errai-jaxrs/errai-jaxrs-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>jaxrs-integration-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <artifactId>errai-jaxrs-provider</artifactId>
 

--- a/errai-jaxrs/errai-jaxrs-provider/pom.xml
+++ b/errai-jaxrs/errai-jaxrs-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>jaxrs-integration-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>errai-jaxrs-provider</artifactId>
 

--- a/errai-jaxrs/pom.xml
+++ b/errai-jaxrs/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/errai-jaxrs/pom.xml
+++ b/errai-jaxrs/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/errai-jboss-as-support/pom.xml
+++ b/errai-jboss-as-support/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <description>Adds support for deployments on JBoss Application Server</description>

--- a/errai-jboss-as-support/pom.xml
+++ b/errai-jboss-as-support/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <description>Adds support for deployments on JBoss Application Server</description>

--- a/errai-jpa/errai-jpa-client/pom.xml
+++ b/errai-jpa/errai-jpa-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>errai-jpa-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
 
   <artifactId>errai-jpa-client</artifactId>

--- a/errai-jpa/errai-jpa-client/pom.xml
+++ b/errai-jpa/errai-jpa-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>errai-jpa-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>errai-jpa-client</artifactId>

--- a/errai-jpa/errai-jpa-datasync/pom.xml
+++ b/errai-jpa/errai-jpa-datasync/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>errai-jpa-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>errai-jpa-datasync</artifactId>

--- a/errai-jpa/errai-jpa-datasync/pom.xml
+++ b/errai-jpa/errai-jpa-datasync/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>errai-jpa-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
 
   <artifactId>errai-jpa-datasync</artifactId>

--- a/errai-jpa/pom.xml
+++ b/errai-jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/errai-jpa/pom.xml
+++ b/errai-jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/errai-js/pom.xml
+++ b/errai-js/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-js/pom.xml
+++ b/errai-js/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-marshalling/pom.xml
+++ b/errai-marshalling/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-marshalling/pom.xml
+++ b/errai-marshalling/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-marshalling/src/main/java/org/jboss/errai/marshalling/rebind/MarshallersGenerator.java
+++ b/errai-marshalling/src/main/java/org/jboss/errai/marshalling/rebind/MarshallersGenerator.java
@@ -338,6 +338,11 @@ public class MarshallersGenerator extends AbstractAsyncGenerator {
     }
   }
 
+  @Override
+  protected boolean isRelevantClass(final MetaClass clazz) {
+    return EnvUtil.isPortableType(clazz.asClass());
+  }
+
   interface DiscoveryContext {
     public void veto();
 

--- a/errai-navigation/pom.xml
+++ b/errai-navigation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-navigation/pom.xml
+++ b/errai-navigation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
@@ -718,7 +718,7 @@ public class NavigationGraphGenerator extends AbstractAsyncGenerator {
   }
 
   @Override
-  protected boolean isRelevantNewClass(MetaClass clazz) {
+  protected boolean isRelevantClass(MetaClass clazz) {
     return clazz.isAnnotationPresent(Page.class);
   }
 }

--- a/errai-otec/pom.xml
+++ b/errai-otec/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-otec/pom.xml
+++ b/errai-otec/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-reflections/pom.xml
+++ b/errai-reflections/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-reflections/pom.xml
+++ b/errai-reflections/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-reflections/reflections/pom.xml
+++ b/errai-reflections/reflections/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai.reflections</groupId>
     <artifactId>reflections-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/errai-reflections/reflections/pom.xml
+++ b/errai-reflections/reflections/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai.reflections</groupId>
     <artifactId>reflections-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/errai-security/errai-security-client/pom.xml
+++ b/errai-security/errai-security-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-security</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <artifactId>errai-security-client</artifactId>
   <name>Errai::Security::Client</name>

--- a/errai-security/errai-security-client/pom.xml
+++ b/errai-security/errai-security-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-security</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>errai-security-client</artifactId>
   <name>Errai::Security::Client</name>

--- a/errai-security/errai-security-keycloak/pom.xml
+++ b/errai-security/errai-security-keycloak/pom.xml
@@ -40,6 +40,11 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
+    <!-- Replacement for commons-logging which was excluded (in paren't depMgmt) from the org.apache.httpcomponents:httpclient. -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.deltaspike.core</groupId>

--- a/errai-security/errai-security-keycloak/pom.xml
+++ b/errai-security/errai-security-keycloak/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-security</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <artifactId>errai-security-keycloak</artifactId>
   <name>Errai::Security::Keycloak</name>

--- a/errai-security/errai-security-keycloak/pom.xml
+++ b/errai-security/errai-security-keycloak/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-security</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>errai-security-keycloak</artifactId>
   <name>Errai::Security::Keycloak</name>

--- a/errai-security/errai-security-keycloak/src/main/java/org/jboss/errai/security/keycloak/KeycloakAuthenticationService.java
+++ b/errai-security/errai-security-keycloak/src/main/java/org/jboss/errai/security/keycloak/KeycloakAuthenticationService.java
@@ -200,7 +200,6 @@ public class KeycloakAuthenticationService implements AuthenticationService, Ser
     properties.add(new KeycloakProperty(StandardUserProperties.FIRST_NAME, accessToken.getGivenName()));
     properties.add(new KeycloakProperty(StandardUserProperties.LAST_NAME, accessToken.getFamilyName()));
     properties.add(new KeycloakProperty(StandardUserProperties.EMAIL, accessToken.getEmail()));
-    properties.add(new KeycloakProperty(AUDIENCE, accessToken.getAudience()));
     properties.add(new KeycloakProperty(BIRTHDATE, accessToken.getBirthdate()));
     properties.add(new KeycloakProperty(GENDER, accessToken.getGender()));
     properties.add(new KeycloakProperty(LOCALE, accessToken.getLocale()));

--- a/errai-security/errai-security-keycloak/src/main/java/org/jboss/errai/security/keycloak/KeycloakAuthenticationService.java
+++ b/errai-security/errai-security-keycloak/src/main/java/org/jboss/errai/security/keycloak/KeycloakAuthenticationService.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.errai.security.keycloak;
 
-import static org.jboss.errai.security.keycloak.properties.KeycloakPropertyNames.AUDIENCE;
 import static org.jboss.errai.security.keycloak.properties.KeycloakPropertyNames.BIRTHDATE;
 import static org.jboss.errai.security.keycloak.properties.KeycloakPropertyNames.COUNTRY;
 import static org.jboss.errai.security.keycloak.properties.KeycloakPropertyNames.EMAIL_VERIFIED;
@@ -182,9 +181,7 @@ public class KeycloakAuthenticationService implements AuthenticationService, Ser
 
   protected User createKeycloakUser(final AccessToken accessToken) {
     final User user = new UserImpl(accessToken.getPreferredUsername(), createRoles(accessToken));
-
     final Collection<KeycloakProperty> properties = getKeycloakUserProperties(accessToken);
-
     for (KeycloakProperty property : properties) {
       if (property.hasValue()) {
         user.setProperty(property.name, property.value);
@@ -230,7 +227,7 @@ public class KeycloakAuthenticationService implements AuthenticationService, Ser
   }
 
   private Collection<? extends Role> createRoles(final AccessToken accessToken) {
-    Set<String> roleNames = accessToken.getResourceAccess(accessToken.getIssuedFor()).getRoles();
+    Set<String> roleNames = accessToken.getRealmAccess().getRoles();
     final List<Role> roles = new ArrayList<Role>(roleNames.size());
     for (final String roleName : roleNames) {
       roles.add(new RoleImpl(roleName));

--- a/errai-security/errai-security-picketlink/pom.xml
+++ b/errai-security/errai-security-picketlink/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-security</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <artifactId>errai-security-picketlink</artifactId>
   <name>Errai::Security::PicketLink</name>

--- a/errai-security/errai-security-picketlink/pom.xml
+++ b/errai-security/errai-security-picketlink/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-security</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>errai-security-picketlink</artifactId>
   <name>Errai::Security::PicketLink</name>

--- a/errai-security/errai-security-server/pom.xml
+++ b/errai-security/errai-security-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-security</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <artifactId>errai-security-server</artifactId>
   <name>Errai::Security::Server</name>

--- a/errai-security/errai-security-server/pom.xml
+++ b/errai-security/errai-security-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-security</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>errai-security-server</artifactId>
   <name>Errai::Security::Server</name>

--- a/errai-security/pom.xml
+++ b/errai-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-security/pom.xml
+++ b/errai-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-tools/pom.xml
+++ b/errai-tools/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-tools/pom.xml
+++ b/errai-tools/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-ui/pom.xml
+++ b/errai-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-ui/pom.xml
+++ b/errai-ui/pom.xml
@@ -103,7 +103,16 @@
           <groupId>org.apache.felix</groupId>
           <artifactId>org.apache.felix.scr.annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging-api</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <!-- Replacement for commons-logging-api excluded from the above org.apache.stanbol.enhancer.engines.htmlextractor -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
 
     <dependency>

--- a/errai-ui/pom.xml
+++ b/errai-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-ui/src/main/java/org/jboss/errai/ui/rebind/less/LessStyleGenerator.java
+++ b/errai-ui/src/main/java/org/jboss/errai/ui/rebind/less/LessStyleGenerator.java
@@ -73,7 +73,7 @@ public class LessStyleGenerator extends AbstractAsyncGenerator {
       // which doesn't get updated otherwise.
       needsToRun = true;
     }
-    
+
     constructor.finish();
     return classBuilder.toJavaString();
   }
@@ -133,9 +133,9 @@ public class LessStyleGenerator extends AbstractAsyncGenerator {
 
     return resource;
   }
-  
+
   @Override
   protected boolean isCacheValid() {
-    return super.isCacheValid() && !needsToRun;
+    return !needsToRun && super.isCacheValid();
   }
 }

--- a/errai-ui/src/main/java/org/jboss/errai/ui/shared/TemplateStyleSheet.java
+++ b/errai-ui/src/main/java/org/jboss/errai/ui/shared/TemplateStyleSheet.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.shared;
+
+import com.google.gwt.resources.client.CssResource;
+
+/**
+ * Interface for retrieving a template stylesheet.
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+public interface TemplateStyleSheet {
+
+  CssResource getStyle();
+
+}

--- a/errai-ui/src/main/java/org/jboss/errai/ui/shared/api/annotations/Templated.java
+++ b/errai-ui/src/main/java/org/jboss/errai/ui/shared/api/annotations/Templated.java
@@ -19,70 +19,70 @@ import com.google.gwt.user.client.ui.Composite;
  * <p>
  * Indicates that the annotated class will participate in the Errai UI templating framework. Instances of the annotated
  * {@link Composite} widget must be retrieved via {@link Inject} or {@link Instance} references in bean classes.
- * 
+ *
  * <p>
- * Unless otherwise specified in the {@link #value()} and {@link #provider()} attributes, a corresponding 
+ * Unless otherwise specified in the {@link #value()} and {@link #provider()} attributes, a corresponding
  * ComponentName.html file must be placed in the same directory on the class-path as the custom ComponentName type.
  * <p>
  * <b>Example:</b>
  * <p>
- * 
+ *
  * <pre>
  * package org.example;
- * 
+ *
  * &#064;Templated
  * public class CustomComponent extends Composite
  * {
  * }
  * </pre>
- * 
+ *
  * <b>And the corresponding HTML template:</b>
- * 
+ *
  * <pre>
  * &lt;form&gt;
  *   &lt;legend&gt;Log in to your account&lt;/legend&gt;
- *  
+ *
  *   &lt;label for="username"&gt;Username&lt;/label&gt;
  *   &lt;input data-field="username" id="username" type="text" placeholder="Username"&gt;
- *  
+ *
  *   &lt;label for="password"&gt;Password&lt;/label&gt;
  *   &lt;input data-field="password" id="password" type="password" placeholder="Password"&gt;
- *  
+ *
  *   &lt;button data-field="login" &gt;Log in&lt;/button&gt;
  *   &lt;button data-field="cancel" &gt;Cancel&lt;/button&gt;
  * &lt;/form&gt;
  * </pre>
  * <p>
- * 
+ *
  * <p>
- * Each element with a <code>id</code>, <code>data-field</code> or <code>class</code> attribute may be bound to a 
- * field, method, or constructor parameter in the annotated class, using the {@link DataField} annotation. Events 
- * triggered by elements or widgets in the template may be handled using the {@link EventHandler} annotation to 
+ * Each element with a <code>id</code>, <code>data-field</code> or <code>class</code> attribute may be bound to a
+ * field, method, or constructor parameter in the annotated class, using the {@link DataField} annotation. Events
+ * triggered by elements or widgets in the template may be handled using the {@link EventHandler} annotation to
  * specify handler methods.
  * <p>
- * 
+ *
  * <pre>
  * package org.example;
- * 
+ *
  * &#064;Templated
  * public class CustomComponent extends Composite
  * {
  *    &#064;Inject
  *    &#064;DataField
  *    private TextBox username;
- * 
+ *
  *    &#064;Inject
  *    &#064;DataField
  *    private TextBox password;
- * 
+ *
  *    &#064;Inject
  *    &#064;DataField
  *    private Button login;
- * 
+ *
  *    &#064;Inject
  *    &#064;DataField
  *    private Button cancel;
- * 
+ *
  *    &#064;EventHandler(&quot;login&quot;)
  *    private void doLogin(ClickEvent event)
  *    {
@@ -92,7 +92,7 @@ import com.google.gwt.user.client.ui.Composite;
  * </pre>
  * <p>
  * <b>Obtaining a widget reference via {@link Inject}:</b>
- * 
+ *
  * <pre>
  * &#064;ApplicationScoped
  * public class ExampleBean
@@ -104,24 +104,24 @@ import com.google.gwt.user.client.ui.Composite;
  * <p>
  * <b>Obtaining widget references on demand, via {@link Instance}.</b> One may also create multiple instances of a
  * {@link Templated} widget using this approach:
- * 
+ *
  * <pre>
  * &#064;ApplicationScoped
  * public class ExampleBean
  * {
  *    &#064;Inject
  *    Instance&lt;CustomComponent&gt; instance;
- * 
+ *
  *    public CustomComponent getNewComponent()
  *    {
  *       return instance.get();
  *    }
  * }
  * </pre>
- * 
+ *
  * <p>
  * <b>See also:</b> {@link DataField}, {@link Bound}, {@link AutoBound}, {@link EventHandler}, {@link SinkNative}
- * 
+ *
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * @author Christian Sadilek <csadilek@redhat.com>
  */
@@ -138,19 +138,29 @@ public @interface Templated
     * qualified class name of the annotated type, plus `.html`. If the fragment is omitted, composition will be
     * performed using the first single element found (and all inner HTML) in the specified template.
     * <p>
-    * The fragment corresponds to an element with matching <code>id</code>, <code>data-field</code> or 
-    * <code>class</code> attribute. If specified, this singleelement (and all inner HTML) will be used as the root 
+    * The fragment corresponds to an element with matching <code>id</code>, <code>data-field</code> or
+    * <code>class</code> attribute. If specified, this singleelement (and all inner HTML) will be used as the root
     * of the widget.
     */
    String value() default "";
 
    /**
-   * Specifies a {@link TemplateProvider} that is used to supply a template at run-time i.e. 
-   * {@link ServerTemplateProvider}. By default, and if omitted, templates must be present at compile-time at the 
-   * class-path location specified by {@link #value()}. 
+   * Specifies the resource path (<code>com/example/foo/CompositeComponent.css</code>) of a CSS stylesheet to be added
+   * to the DOM when this component is created.
+   * <p>
+   * The resource path is the location of the CSS file on the classpath. If omitted, this defaults to the fully
+   * qualified class name of the annotated type, plus `.css`, in which case it is not an error if the CSS file is not
+   * found. For non-default values, missing stylesheets will cause rebind errors.
    */
-   Class<? extends TemplateProvider> provider() default 
+   String stylesheet() default "";
+
+   /**
+   * Specifies a {@link TemplateProvider} that is used to supply a template at run-time i.e.
+   * {@link ServerTemplateProvider}. By default, and if omitted, templates must be present at compile-time at the
+   * class-path location specified by {@link #value()}.
+   */
+   Class<? extends TemplateProvider> provider() default
      org.jboss.errai.ui.shared.api.annotations.Templated.DEFAULT_PROVIDER.class;
-   
+
    static abstract class DEFAULT_PROVIDER implements TemplateProvider {}
 }

--- a/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponent.css
+++ b/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponent.css
@@ -1,0 +1,3 @@
+.styled {
+  font-size: 100px;
+}

--- a/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponent.html
+++ b/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponent.html
@@ -1,0 +1,3 @@
+<div data-field="root">
+  <span data-field="styled" class="styled"></span>
+</div>

--- a/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponent.java
+++ b/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponent.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.test.basic.client.res;
+
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.user.client.ui.Composite;
+
+/**
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Templated
+public class StyledComponent extends Composite implements StyledTemplatedBean {
+
+  @DataField
+  private final SpanElement styled = Document.get().createSpanElement();
+
+  @Override
+  public SpanElement getStyled() {
+    return styled;
+  }
+
+}

--- a/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponentWithAbsoluteSheetPath.java
+++ b/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponentWithAbsoluteSheetPath.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.test.basic.client.res;
+
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.user.client.ui.Composite;
+
+/**
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Templated(value = "StyledComponent.html", stylesheet = "/org/jboss/errai/ui/test/basic/client/res/absolute.css")
+public class StyledComponentWithAbsoluteSheetPath extends Composite implements StyledTemplatedBean {
+
+  @DataField
+  private final SpanElement styled = Document.get().createSpanElement();
+
+  @Override
+  public SpanElement getStyled() {
+    return styled;
+  }
+
+}

--- a/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponentWithRelativeSheetPath.java
+++ b/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledComponentWithRelativeSheetPath.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.test.basic.client.res;
+
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.user.client.ui.Composite;
+
+/**
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Templated(value = "StyledComponent.html", stylesheet = "relative.css")
+public class StyledComponentWithRelativeSheetPath extends Composite implements StyledTemplatedBean {
+
+  @DataField
+  private final SpanElement styled = Document.get().createSpanElement();
+
+  @Override
+  public SpanElement getStyled() {
+    return styled;
+  }
+
+}

--- a/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledTemplatedBean.java
+++ b/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/StyledTemplatedBean.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.test.basic.client.res;
+
+import com.google.gwt.dom.client.SpanElement;
+
+/**
+ * 
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+public interface StyledTemplatedBean {
+
+  SpanElement getStyled();
+
+}

--- a/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/absolute.css
+++ b/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/absolute.css
@@ -1,0 +1,3 @@
+.styled {
+  margin: 10px;
+}

--- a/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/relative.css
+++ b/errai-ui/src/test/java/org/jboss/errai/ui/test/basic/client/res/relative.css
@@ -1,0 +1,3 @@
+.styled {
+  font-color: red;
+}

--- a/errai-uibinder/pom.xml
+++ b/errai-uibinder/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-uibinder/pom.xml
+++ b/errai-uibinder/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.jboss.errai</groupId>
     <artifactId>errai-parent</artifactId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-validation/pom.xml
+++ b/errai-validation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.1.Final</version>
+    <version>3.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-validation/pom.xml
+++ b/errai-validation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>errai-parent</artifactId>
     <groupId>org.jboss.errai</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>Errai</name>
   <groupId>org.jboss.errai</groupId>
   <artifactId>errai-parent</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.2.Final</version>
   <packaging>pom</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>Errai</name>
   <groupId>org.jboss.errai</groupId>
   <artifactId>errai-parent</artifactId>
-  <version>3.2.1.Final</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <url>http://jboss.org/errai/errai</url>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
       <dependency>
         <groupId>org.jboss.integration-platform</groupId>
         <artifactId>jboss-integration-platform-bom</artifactId>
-        <version>6.0.0.CR29</version>
+        <version>6.0.0.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Max,
I just found an issue with Keycloak 1.7.Final and Errai 3.2.2.Final, which is likely in the upcoming KC 1.8.Final as well (to be released this week). Attched is a debugger screenshot which shows what happens **without the fix**: Trying to obtain the set of roles of an authenticated user via:
 ```
Set<String> roleNames = accessToken.getResourceAccess(accessToken.getIssuedFor()) .getRoles()
```
results in NPE:
```
java.lang.NullPointerException
org.jboss.errai.security.keycloak.KeycloakAuthenticationService.createRoles(KeycloakAuthenticationService.java:233)
org.jboss.errai.security.keycloak.KeycloakAuthenticationService.createKeycloakUser(KeycloakAuthenticationService.java:184)
org.jboss.errai.security.keycloak.KeycloakAuthenticationService.getKeycloakUser(KeycloakAuthenticationService.java:177)
org.jboss.errai.security.keycloak.KeycloakAuthenticationService.getUser(KeycloakAuthenticationService.java:160)
org.jboss.errai.security.keycloak.KeycloakAuthenticationService$Proxy$_$$_WeldClientProxy.getUser(Unknown Source)
org.jboss.errai.security.server.servlet.UserCookieFilter.maybeSetUserCookie(UserCookieFilter.java:94)
org.jboss.errai.security.server.servlet.UserCookieFilter.doFilter(UserCookieFilter.java:71)
io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:60)
io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:132)
io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:85)
io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
io.undertow.jsp.JspFileHandler.handleRequest(JspFileHandler.java:32)
io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
org.keycloak.adapters.undertow.UndertowAuthenticatedActionsHandler.handleRequest(UndertowAuthenticatedActionsHandler.java:66)
io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
io.undertow.security.handlers.AuthenticationConstraintHandler.handleRequest(AuthenticationConstraintHandler.java:51)
io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
io.undertow.servlet.handlers.security.ServletSecurityConstraintHandler.handleRequest(ServletSecurityConstraintHandler.java:56)
io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:58)
io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:72)
io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
io.undertow.security.handlers.SecurityInitialHandler.handleRequest(SecurityInitialHandler.java:76)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
org.keycloak.adapters.undertow.ServletPreAuthActionsHandler.handleRequest(ServletPreAuthActionsHandler.java:69)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:282)
io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:261)
io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:80)
io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:172)
io.undertow.server.Connectors.executeRootHandler(Connectors.java:199)
io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:774)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
java.lang.Thread.run(Thread.java:745)
```
 as the screenshot shows that in KC1.7 accessToken.resourceAccess has different stuff. The roles can still be obtained via the AccessToken.realAccess and the (new) Access class (again, see the attached debugger screenshot), which is how the fix works:
```
 Set<String> roleNames = accessToken.getRealmAccess().getRoles();
```

Can you, please, review this PR and provide it in either 3.2-SHAPSHOT or release 3.2.3.Final, so I can use the Errai maven repo? Thanks.

![selection_041](https://cloud.githubusercontent.com/assets/5327044/12409627/c4da1602-be20-11e5-9abd-c4f8b2691622.png)