### PR TITLE
ValueBox<T> implements both HasText and TakesValue<T>.  TakesValue<T>…

### DIFF
--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/api/Convert.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/api/Convert.java
@@ -302,10 +302,7 @@ public class Convert {
   public static Class inferWidgetValueType(Widget widget, Class<?> defaultWidgetValueType) {
     Class widgetValueType = null;
 
-    if (widget instanceof HasText) {
-      widgetValueType = String.class;
-    }
-    else if (widget instanceof ElementWrapperWidget) {
+    if (widget instanceof ElementWrapperWidget) {
       widgetValueType = ((ElementWrapperWidget<?>) widget).getValueType();
     }
     else if (widget instanceof TakesValue) {
@@ -334,6 +331,9 @@ public class Convert {
       else {
         widgetValueType = defaultWidgetValueType;
       }
+    }
+    else if (widget instanceof HasText) {
+        widgetValueType = String.class;
     }
     else {
       widgetValueType = String.class;

--- a/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/DataBindingIntegrationTest.java
+++ b/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/DataBindingIntegrationTest.java
@@ -59,6 +59,7 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.event.dom.client.DomEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.IntegerBox;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextBox;
 
@@ -91,6 +92,25 @@ public class DataBindingIntegrationTest extends AbstractErraiIOCTest {
 
     model.setValue("model change");
     assertEquals("Widget not properly updated", "model change", textBox.getText());
+  }
+  
+  @Test
+  public void testBindingWithHasTextAndHasValue() {
+    IntegerBox integerBox = new IntegerBox();
+    TestModel model = DataBinder.forType(TestModel.class).bind(integerBox, "age").getModel();
+
+    integerBox.setValue(5, true);
+    assertEquals("Model not properly updated", (Integer) 5, model.getAge());
+
+    model.setAge(3);
+    assertEquals("Widget not properly updated", "3", integerBox.getText());
+
+    integerBox.setValue(null, true);
+    assertEquals("Model not properly updated", (Integer) null, model.getAge());
+    
+    model.setAge(null);
+    assertEquals("Widget not properly updated", "", integerBox.getText());
+
   }
 
   @Test


### PR DESCRIPTION
… should take precedence over HasText.  Otherwise, inferWidgetValueType( ValueBox<BigDecimal> w ) will resolve to String, when it should resolve to BigDecimal.  This ends up causing a ClassCastException when binding occurs.