### PR TITLE
Exclude javassist:javassist which collides with org.javassist:javassist

### DIFF
--- a/errai-security/errai-security-server/pom.xml
+++ b/errai-security/errai-security-server/pom.xml
@@ -58,6 +58,18 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-cdi</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Replacement for javassist:javassist excluded from resteasy-cdi -->
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <scope>runtime</scope>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
@csadilek, I've basically replaced the old javassist with new one, so this should be fine. In any case, we can't really have two artifacts with same FQCN on classpath. There is no guarantee which one will be picked up and this leads to very hard to find issues.