### PR TITLE
Default http and native remoting addresses overridable

### DIFF
--- a/JBossLauncher.java
+++ b/JBossLauncher.java
@@ -1,0 +1,203 @@
+package org.jboss.errai.cdi.server.gwt;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.BindException;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.commons.io.IOUtils;
+import org.jboss.errai.cdi.server.as.JBossServletContainerAdaptor;
+import org.jboss.errai.cdi.server.gwt.util.SimpleTranslator;
+import org.jboss.errai.cdi.server.gwt.util.SimpleTranslator.AttributeEntry;
+import org.jboss.errai.cdi.server.gwt.util.SimpleTranslator.Tag;
+import org.jboss.errai.cdi.server.gwt.util.StackTreeLogger;
+import org.jboss.errai.cdi.server.gwt.util.JBossUtil;
+
+import com.google.gwt.core.ext.ServletContainer;
+import com.google.gwt.core.ext.ServletContainerLauncher;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.TreeLogger.Type;
+import com.google.gwt.core.ext.UnableToCompleteException;
+
+/**
+ * For starting a {@link JBossServletContainerAdaptor} controlling a standalone
+ * Jboss/Wildfly AS.
+ * 
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+public class JBossLauncher extends ServletContainerLauncher {
+
+  // Property names
+  private final String JBOSS_DEBUG_PORT_PROPERTY = "errai.jboss.debug.port";
+  private final String TEMPLATE_CONFIG_FILE_PROPERTY = "errai.jboss.config.file";
+  private final String CLASS_HIDING_JAVA_AGENT_PROPERTY = "errai.jboss.javaagent.path";
+  private final String JBOSS_JAVA_OPTS_PROPERTY = "errai.jboss.javaopts";
+  private final String TMP_CONFIG_FILE = "standalone-errai-dev.xml";
+  
+  // Added 02/13/2016
+  private final String JBOSS_HTTP_REMOTING_ADDRESS     = "errai.jboss.httpremotingaddress";
+  private final String JBOSS_NATIVE_REMOTING_ADDRESS  = "errai.jboss.nativeremotingaddress";
+
+  private StackTreeLogger logger;
+
+  @Override
+  public ServletContainer start(TreeLogger treeLogger, int port, File appRootDir) throws BindException, Exception {
+    logger = new StackTreeLogger(treeLogger);
+
+    logger.branch(Type.INFO, "JBoss / WildFly launcher starting..");
+
+    // Get properties
+    final String DEBUG_PORT 		     = System.getProperty(JBOSS_DEBUG_PORT_PROPERTY, "8001");
+    final String TEMPLATE_CONFIG_FILE    = System.getProperty(TEMPLATE_CONFIG_FILE_PROPERTY, "standalone-full.xml");
+    final String CLASS_HIDING_JAVA_AGENT = System.getProperty(CLASS_HIDING_JAVA_AGENT_PROPERTY);
+    String JAVA_OPTS = System.getProperty(JBOSS_JAVA_OPTS_PROPERTY, "");
+    
+    // Added new properties to allow overriding of default ones.
+    final String HTTP_REMOTING_ADDRESS      =System.getProperty(JBOSS_HTTP_REMOTING_ADDRESS, "http-remoting://localhost:9990");
+    final String NATIVE_REMOTING_ADDRESS    =System.getProperty(JBOSS_NATIVE_REMOTING_ADDRESS, "remote://localhost:9999");
+
+    final String jbossHome = JBossUtil.getJBossHome(logger);
+    validateClassHidingJavaAgent(CLASS_HIDING_JAVA_AGENT);
+
+    try {
+      createTempConfigFile(TEMPLATE_CONFIG_FILE, TMP_CONFIG_FILE, jbossHome, port);
+      logger.log(Type.INFO,
+              String.format("Created temporary config file %s, copied from %s.", TMP_CONFIG_FILE, TEMPLATE_CONFIG_FILE));
+    }
+    catch (IOException e) {
+      logger.log(
+              Type.ERROR,
+              String.format("Unable to create temporary config file %s from %s", TMP_CONFIG_FILE, TEMPLATE_CONFIG_FILE),
+              e);
+    }
+
+    final String JBOSS_START = JBossUtil.getStartScriptName(jbossHome);
+
+    Process process;
+    try {
+      logger.branch(Type.INFO, String.format("Preparing JBoss AS instance (%s)", JBOSS_START));
+      final File startScript = new File(JBOSS_START);
+      if (!startScript.canExecute() && !startScript.setExecutable(true)) {
+        logger.log(Type.ERROR, "Can not execute " + JBOSS_START);
+        throw new UnableToCompleteException();
+      }
+      ProcessBuilder builder = new ProcessBuilder(JBOSS_START, "-c", TMP_CONFIG_FILE);
+
+      logger.log(Type.INFO, String.format("Adding JBOSS_HOME=%s to instance environment", jbossHome));
+      // Necessary for JBoss AS instance to startup
+      builder.environment().put("JBOSS_HOME", jbossHome);
+
+      // Allows JVM to be debugged
+      builder.environment().put(
+              "JAVA_OPTS",
+              String.format("%s -Xrunjdwp:transport=dt_socket,address=%s,server=y,suspend=n -javaagent:%s", JAVA_OPTS,
+                      DEBUG_PORT, CLASS_HIDING_JAVA_AGENT).trim());
+
+      process = builder.start();
+
+      logger.log(Type.INFO, "Redirecting stdout and stderr to share with this process");
+      inheritIO(process.getInputStream(), System.out);
+      inheritIO(process.getErrorStream(), System.err);
+
+      logger.log(Type.INFO, "Executing AS instance...");
+    }
+    catch (IOException e) {
+      logger.log(TreeLogger.Type.ERROR, "Failed to start JBoss AS process", e);
+      logger.unbranch();
+      throw new UnableToCompleteException();
+    }
+
+    logger.unbranch();
+
+    logger.branch(Type.INFO, "Creating servlet container controller...");
+
+    try {
+      
+      JBossServletContainerAdaptor controller = new JBossServletContainerAdaptor(port, appRootDir, JBossUtil.getDeploymentContext(), logger.peek(), process, HTTP_REMOTING_ADDRESS, NATIVE_REMOTING_ADDRESS);
+      
+      logger.log(Type.INFO, "Controller created");
+      logger.unbranch();
+      return controller;
+    }
+    catch (UnableToCompleteException e) {
+      logger.log(Type.ERROR, "Could not start servlet container controller", e);
+      throw new UnableToCompleteException();
+    }
+  }
+
+  private void validateClassHidingJavaAgent(final String CLASS_HIDING_JAVA_AGENT) throws UnableToCompleteException {
+    if (CLASS_HIDING_JAVA_AGENT == null) {
+      logger.log(
+              Type.ERROR,
+              String.format(
+                      "The local path to the artifact errai.org.jboss:class-local-class-hider:jar must be given as the property %s",
+                      CLASS_HIDING_JAVA_AGENT_PROPERTY));
+      throw new UnableToCompleteException();
+    }
+  }
+
+  private void createTempConfigFile(String fromName, String toName, String jBossHome, int port) throws IOException,
+          UnableToCompleteException {
+    File configDir = new File(jBossHome, JBossUtil.STANDALONE_CONFIGURATION);
+    File from = new File(configDir, fromName);
+    File to = new File(configDir, toName);
+
+    if (!from.exists()) {
+      logger.log(
+              Type.ERROR,
+              String.format(
+                      "Config file %s does not exit. It must be created or another one must be specified with the %s JVM property.",
+                      from.getAbsolutePath(), TEMPLATE_CONFIG_FILE_PROPERTY));
+      throw new UnableToCompleteException();
+    }
+
+    if (to.exists()) {
+      logger.log(Type.WARN,
+              String.format("Temporary config file %s already exists and will be deleted", to.getAbsolutePath()));
+      to.delete();
+    }
+
+    to.createNewFile();
+    to.deleteOnExit();
+
+    InputStream inStream = new FileInputStream(from);
+    OutputStream outStream = new FileOutputStream(to);
+
+    // Replace default http port with provided port
+    SimpleTranslator trans = new SimpleTranslator();
+    trans.addFilter(new Tag("socket-binding", new AttributeEntry("name", "http")));
+    trans.addNewTag("socket-binding-group", new Tag("socket-binding", new AttributeEntry("name", "http"),
+            new AttributeEntry("port", String.valueOf(port))));
+
+    try {
+      trans.translate(inStream, outStream);
+    }
+    catch (XMLStreamException e) {
+      logger.log(Type.ERROR, "Could not create copy of configuration from " + from.getAbsolutePath(), e);
+      throw new UnableToCompleteException();
+    }
+    finally {
+      inStream.close();
+      outStream.close();
+    }
+  }
+
+  private void inheritIO(final InputStream in, final OutputStream to) {
+    new Thread() {
+      @Override
+      public void run() {
+        try {
+          IOUtils.copy(in, to);
+        }
+        catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }.start();
+  }
+}

--- a/JBossServletContainerAdaptor.java
+++ b/JBossServletContainerAdaptor.java
@@ -1,0 +1,334 @@
+package org.jboss.errai.cdi.server.as;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jboss.as.cli.CliInitializationException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.errai.cdi.server.gwt.util.StackTreeLogger;
+
+import com.google.gwt.core.ext.ServletContainer;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.TreeLogger.Type;
+import com.google.gwt.core.ext.UnableToCompleteException;
+
+/**
+ * Acts as a an adaptor between gwt's ServletContainer interface and a JBoss
+ * AS/WildFly instance.
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ * @author Christian Sadilek <csadilek@redhat.com>
+ */
+public class JBossServletContainerAdaptor extends ServletContainer {
+
+  private final CommandContext ctx;
+
+  private final int port;
+  private final StackTreeLogger logger;
+  private final String context;
+  @SuppressWarnings("unused")
+  private final Process jbossProcess;
+
+  private static String NATIVE_CONTROLLER_PATH = "remote://localhost:9999";
+  private static String HTTP_CONTROLLER_PATH = "http-remoting://localhost:9990";
+  private static final int MAX_RETRIES = 9;
+
+  /**
+   * Initialize the command context for a remote JBoss AS instance.
+   *
+   * @param port
+   *          The port to which the JBoss instance binds.
+   * @param appRootDir
+   *          The exploded war directory to be deployed.
+   * @param context
+   *          The deployment context for the app.
+   * @param treeLogger
+   *          For logging events from this container.
+   * @throws UnableToCompleteException
+   *           Thrown if this container cannot properly connect or deploy.
+   */
+  
+  public JBossServletContainerAdaptor(int port, File appRootDir, String context, TreeLogger treeLogger,
+          Process jbossProcess) throws UnableToCompleteException {
+	  this(port,appRootDir,context,treeLogger,jbossProcess,null, null);
+  }
+  
+  /**
+   * Initialize the command context for a remote JBoss AS instance.
+   *
+   * @param port
+   *          The port to which the JBoss instance binds.
+   * @param appRootDir
+   *          The exploded war directory to be deployed.
+   * @param context
+   *          The deployment context for the app.
+   * @param treeLogger
+   *          For logging events from this container.
+   * @param httpRemotingAddress
+   * 		  If not null, overrides HTTP_CONTROLLER_PATH property with the specified one.
+   * @param nativeRemotingAddress
+   * 		  If not null, overrides NATIVE_CONTROLLER_PATH property with the specified one.
+   * 
+   * @throws UnableToCompleteException
+   *           Thrown if this container cannot properly connect or deploy.
+   */
+  public JBossServletContainerAdaptor(int port, File appRootDir, String context, TreeLogger treeLogger,
+          Process jbossProcess,String httpRemotingAddress, String nativeRemotingAddress ) throws UnableToCompleteException {
+    this.port = port;
+    logger = new StackTreeLogger(treeLogger);
+    this.jbossProcess = jbossProcess;
+    this.context = context;
+    
+    logger.branch(Type.INFO, "Starting container initialization...");
+    // Overrides remoting address if and only if an ovverride is passed.
+    if(httpRemotingAddress != null && !httpRemotingAddress.trim().equalsIgnoreCase(HTTP_CONTROLLER_PATH)) {
+    	logger.branch(Type.INFO, "Changing default HTTP_CONTROLLER_PATH property from ["+HTTP_CONTROLLER_PATH+"] to ["+httpRemotingAddress+"]");
+    	HTTP_CONTROLLER_PATH = httpRemotingAddress;
+    }
+
+    if(nativeRemotingAddress != null && !nativeRemotingAddress.trim().equalsIgnoreCase(NATIVE_CONTROLLER_PATH)) {
+    	logger.branch(Type.INFO, "Changing default NATIVE_CONTROLLER_PATH property from ["+NATIVE_CONTROLLER_PATH+"] to ["+nativeRemotingAddress+"]");
+    	NATIVE_CONTROLLER_PATH = nativeRemotingAddress;
+    }
+
+    
+    CommandContext ctx = null;
+    try {
+      // Create command context
+      try {
+
+        logger.branch(Type.INFO, "Creating new command context...");
+        ctx = CommandContextFactory.getInstance().newCommandContext();
+        this.ctx = ctx;
+
+        logger.log(Type.INFO, "Command context created");
+        logger.unbranch();
+      }
+      catch (CliInitializationException e) {
+        logger.branch(TreeLogger.Type.ERROR, "Could not initialize JBoss AS command context", e);
+        throw new UnableToCompleteException();
+      }
+
+      attemptCommandContextConnection(MAX_RETRIES);
+
+      try {
+        // Undeploy the app in case the container/devmode wasn't shutdown correctly which should
+        // have removed the deployment (see stop method).
+        removeDeployment();
+        
+        /*
+         * Need to add deployment resource to specify exploded archive
+         *
+         * path : the absolute path the deployment file/directory archive : true
+         * iff the an archived file, false iff an exploded archive enabled :
+         * true iff war should be automatically scanned and deployed
+         */
+        logger.branch(Type.INFO,
+                String.format("Adding deployment %s at %s...", getAppName(), appRootDir.getAbsolutePath()));
+
+        final ModelNode operation = getAddOperation(appRootDir.getAbsolutePath());
+        final ModelNode result = ctx.getModelControllerClient().execute(operation);
+        if (!Operations.isSuccessfulOutcome(result)) {
+          logger.log(Type.ERROR, String.format("Could not add deployment:\nInput:\n%s\nOutput:\n%s",
+                  operation.toJSONString(false), result.toJSONString(false)));
+          throw new UnableToCompleteException();
+        }
+
+        logger.log(Type.INFO, "Deployment resource added");
+        logger.unbranch();
+      }
+      catch (IOException e) {
+        logger.branch(Type.ERROR, String.format("Could not add deployment %s", getAppName()), e);
+        throw new UnableToCompleteException();
+      }
+
+      attemptDeploy();
+
+    }
+    catch (UnableToCompleteException e) {
+      logger.branch(Type.INFO, "Attempting to stop container...");
+      stopHelper();
+
+      throw e;
+    }
+
+  }
+
+  @Override
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public void refresh() throws UnableToCompleteException {
+    attemptDeploymentRelatedOp(ClientConstants.DEPLOYMENT_REDEPLOY_OPERATION);
+  }
+
+  @Override
+  public void stop() throws UnableToCompleteException {
+    try {
+      logger.branch(Type.INFO, String.format("Removing %s from deployments...", getAppName()));
+
+      ModelNode result = removeDeployment();
+      if (!Operations.isSuccessfulOutcome(result)) {
+        logger.log(
+                Type.ERROR,
+                String.format("Could not undeploy AS:\nInput:\n%s\nOutput:\n%s", getAppName(),
+                        result.toJSONString(false)));
+        throw new UnableToCompleteException();
+      }
+
+      logger.log(Type.INFO, String.format("%s removed", getAppName()));
+      logger.unbranch();
+    }
+    catch (IOException e) {
+      logger.log(Type.ERROR, "Could not shutdown AS", e);
+      throw new UnableToCompleteException();
+    }
+    finally {
+      stopHelper();
+    }
+  }
+
+  private ModelNode removeDeployment() throws IOException {
+    final ModelNode operation = Operations.createRemoveOperation(
+            new ModelNode().add(ClientConstants.DEPLOYMENT, getAppName()));
+    return ctx.getModelControllerClient().execute(operation);
+  }
+  
+  private void attemptCommandContextConnection(final int maxRetries)
+          throws UnableToCompleteException {
+
+    String[] controllers = new String[] { HTTP_CONTROLLER_PATH,  NATIVE_CONTROLLER_PATH  };
+    
+    final String[] protocols = new String[controllers.length];
+    for (int i = 0; i < controllers.length; i++) {
+      protocols[i] = controllers[i].split(":", 2)[0];
+    }
+
+    for (int retry = 0; retry < maxRetries; retry++) {
+      for (int i = 0; i < controllers.length; i++) {
+        final String controller = controllers[i];
+        final String protocol = protocols[i];
+        try {
+          logger.branch(Type.INFO, String.format("Attempting to connect with %s protocol.", protocol));
+          ctx.connectController(controller);
+          logger.log(Type.INFO, "Connected to JBoss AS");
+
+          return;
+        }
+        catch (CommandLineException e) {
+          logger.log(
+                  Type.INFO,
+                  String.format("Attempt %d failed at connecting with %s protocol", retry + 1, protocol),
+                  e);
+        }
+        finally {
+          logger.unbranch();
+        }
+      }
+
+      // No connection attempts have succeeded, so wait a bit before trying
+      // again.
+      if (retry < maxRetries) {
+        try {
+          Thread.sleep(1000);
+        }
+        catch (InterruptedException e1) {
+          logger.log(Type.WARN, "Thread was interrupted while waiting for AS to reload", e1);
+        }
+      }
+    }
+
+    logger.log(Type.ERROR, "Could not connect to AS");
+    throw new UnableToCompleteException();
+  }
+
+  private void stopHelper() {
+    logger.branch(Type.INFO, "Attempting to stop JBoss AS instance...");
+    /*
+     * There is a problem with Process#destroy where it will not reliably kill
+     * the JBoss instance. So instead we must try and send a shutdown signal. If
+     * that is not possible or does not work, we will log it's failure, advising
+     * the user to manually kill this process.
+     */
+    try {
+      if (ctx.getControllerHost() == null) {
+        ctx.handle("connect localhost:9999");
+      }
+      ctx.handle(":shutdown");
+
+      logger.log(Type.INFO, "JBoss AS instance stopped");
+      logger.unbranch();
+    }
+    catch (CommandLineException e) {
+      logger.log(Type.ERROR, "Could not shutdown JBoss AS instance. "
+              + "Restarting this container while a JBoss AS instance is still running will cause errors.");
+    }
+
+    logger.branch(Type.INFO, "Terminating command context...");
+    ctx.terminateSession();
+    logger.log(Type.INFO, "Command context terminated");
+    logger.unbranch();
+  }
+
+  private void attemptDeploy() throws UnableToCompleteException {
+    attemptDeploymentRelatedOp(ClientConstants.DEPLOYMENT_DEPLOY_OPERATION);
+  }
+
+  private void attemptDeploymentRelatedOp(final String opName) throws UnableToCompleteException {
+    try {
+      logger.branch(Type.INFO, String.format("Deploying %s...", getAppName()));
+
+      final ModelNode operation = Operations.createOperation(opName,
+              new ModelNode().add(ClientConstants.DEPLOYMENT, getAppName()));
+      final ModelNode result = ctx.getModelControllerClient().execute(operation);
+
+      if (!Operations.isSuccessfulOutcome(result)) {
+        logger.log(
+                Type.ERROR,
+                String.format("Could not %s %s:\nInput:\n%s\nOutput:\n%s", opName, getAppName(),
+                        operation.toJSONString(false), result.toJSONString(false)));
+        throw new UnableToCompleteException();
+      }
+
+      logger.log(Type.INFO, String.format("%s %sed", getAppName(), opName));
+      logger.unbranch();
+    }
+    catch (IOException e) {
+      logger.branch(Type.ERROR, String.format("Could not %s %s", opName, getAppName()), e);
+      throw new UnableToCompleteException();
+    }
+  }
+
+  /**
+   * @return The runtime-name for the given deployment.
+   */
+  private String getAppName() {
+    // Deployment names must end with .war
+    return context.endsWith(".war") ? context : context + ".war";
+  }
+
+  private ModelNode getAddOperation(String path) {
+    final ModelNode command = Operations.createAddOperation(new ModelNode().add(ClientConstants.DEPLOYMENT,
+            getAppName()));
+    final ModelNode content = new ModelNode();
+    final ModelNode contentObj = new ModelNode();
+
+    // Construct content list
+    contentObj.get("path").set(path);
+    contentObj.get("archive").set(false);
+    content.add(contentObj);
+
+    command.get("content").set(content);
+    command.get("enabled").set(false);
+
+    return command;
+  }
+  
+}


### PR DESCRIPTION
JBossLauncher by default tries to connect to local instance of Wildfly on localhost:9990.
There are cases when Wildfly needs to be bound on a different port. To allow this, I propose to add two new properties ("errai.jboss.httpremotingaddress" and  "errai.jboss.nativeremotingaddress") to override defaults.
Have a look at https://developer.jboss.org/thread/267680 discussion for further details.

