### PR TITLE
Made http and native remoting addresses overridable via properties

### DIFF
--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/as/JBossServletContainerAdaptor.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/as/JBossServletContainerAdaptor.java
@@ -34,8 +34,8 @@ public class JBossServletContainerAdaptor extends ServletContainer {
   @SuppressWarnings("unused")
   private final Process jbossProcess;
 
-  private static String NATIVE_CONTROLLER_PATH = "remote://localhost:9999";
-  private static String HTTP_CONTROLLER_PATH = "http-remoting://localhost:9990";
+  private String nativeControllerPath = "remote://localhost:9999";
+  private String httpControllerPath = "http-remoting://localhost:9990";
   private static final int MAX_RETRIES = 9;
 
   /**
@@ -51,7 +51,7 @@ public class JBossServletContainerAdaptor extends ServletContainer {
    *          For logging events from this container.
    * @throws UnableToCompleteException
    *           Thrown if this container cannot properly connect or deploy.
-   */
+   */ 
   
   public JBossServletContainerAdaptor(int port, File appRootDir, String context, TreeLogger treeLogger,
           Process jbossProcess) throws UnableToCompleteException {
@@ -86,14 +86,14 @@ public class JBossServletContainerAdaptor extends ServletContainer {
     
     logger.branch(Type.INFO, "Starting container initialization...");
     // Overrides remoting address if and only if an ovverride is passed.
-    if(httpRemotingAddress != null && !httpRemotingAddress.trim().equalsIgnoreCase(HTTP_CONTROLLER_PATH)) {
-    	logger.branch(Type.INFO, "Changing default HTTP_CONTROLLER_PATH property from ["+HTTP_CONTROLLER_PATH+"] to ["+httpRemotingAddress+"]");
-    	HTTP_CONTROLLER_PATH = httpRemotingAddress;
+    if (httpRemotingAddress != null && !httpRemotingAddress.trim().equalsIgnoreCase(httpControllerPath)) {
+    	logger.branch(Type.INFO, "Changing default 'httpControllerPath' property from ["+httpControllerPath+"] to ["+httpRemotingAddress+"]");
+    	httpControllerPath = httpRemotingAddress;
     }
 
-    if(nativeRemotingAddress != null && !nativeRemotingAddress.trim().equalsIgnoreCase(NATIVE_CONTROLLER_PATH)) {
-    	logger.branch(Type.INFO, "Changing default NATIVE_CONTROLLER_PATH property from ["+NATIVE_CONTROLLER_PATH+"] to ["+nativeRemotingAddress+"]");
-    	NATIVE_CONTROLLER_PATH = nativeRemotingAddress;
+    if (nativeRemotingAddress != null && !nativeRemotingAddress.trim().equalsIgnoreCase(nativeControllerPath)) {
+    	logger.branch(Type.INFO, "Changing default 'nativeControllerPath' property from ["+nativeControllerPath+"] to ["+nativeRemotingAddress+"]");
+    	nativeControllerPath = nativeRemotingAddress;
     }
 
     
@@ -204,7 +204,7 @@ public class JBossServletContainerAdaptor extends ServletContainer {
   private void attemptCommandContextConnection(final int maxRetries)
           throws UnableToCompleteException {
 
-    String[] controllers = new String[] { HTTP_CONTROLLER_PATH,  NATIVE_CONTROLLER_PATH  };
+    String[] controllers = new String[] { httpControllerPath,  nativeControllerPath  };
     
     final String[] protocols = new String[controllers.length];
     for (int i = 0; i < controllers.length; i++) {

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/as/JBossServletContainerAdaptor.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/as/JBossServletContainerAdaptor.java
@@ -34,8 +34,8 @@ public class JBossServletContainerAdaptor extends ServletContainer {
   @SuppressWarnings("unused")
   private final Process jbossProcess;
 
-  private static final String NATIVE_CONTROLLER_PATH = "remote://localhost:9999";
-  private static final String HTTP_CONTROLLER_PATH = "http-remoting://localhost:9990";
+  private static String NATIVE_CONTROLLER_PATH = "remote://localhost:9999";
+  private static String HTTP_CONTROLLER_PATH = "http-remoting://localhost:9990";
   private static final int MAX_RETRIES = 9;
 
   /**
@@ -52,15 +52,51 @@ public class JBossServletContainerAdaptor extends ServletContainer {
    * @throws UnableToCompleteException
    *           Thrown if this container cannot properly connect or deploy.
    */
+  
   public JBossServletContainerAdaptor(int port, File appRootDir, String context, TreeLogger treeLogger,
           Process jbossProcess) throws UnableToCompleteException {
+	  this(port,appRootDir,context,treeLogger,jbossProcess,null, null);
+  }
+  
+  /**
+   * Initialize the command context for a remote JBoss AS instance.
+   *
+   * @param port
+   *          The port to which the JBoss instance binds.
+   * @param appRootDir
+   *          The exploded war directory to be deployed.
+   * @param context
+   *          The deployment context for the app.
+   * @param treeLogger
+   *          For logging events from this container.
+   * @param httpRemotingAddress
+   * 		  If not null, overrides HTTP_CONTROLLER_PATH property with the specified one.
+   * @param nativeRemotingAddress
+   * 		  If not null, overrides NATIVE_CONTROLLER_PATH property with the specified one.
+   * 
+   * @throws UnableToCompleteException
+   *           Thrown if this container cannot properly connect or deploy.
+   */
+  public JBossServletContainerAdaptor(int port, File appRootDir, String context, TreeLogger treeLogger,
+          Process jbossProcess,String httpRemotingAddress, String nativeRemotingAddress ) throws UnableToCompleteException {
     this.port = port;
     logger = new StackTreeLogger(treeLogger);
     this.jbossProcess = jbossProcess;
     this.context = context;
-
+    
     logger.branch(Type.INFO, "Starting container initialization...");
+    // Overrides remoting address if and only if an ovverride is passed.
+    if(httpRemotingAddress != null && !httpRemotingAddress.trim().equalsIgnoreCase(HTTP_CONTROLLER_PATH)) {
+    	logger.branch(Type.INFO, "Changing default HTTP_CONTROLLER_PATH property from ["+HTTP_CONTROLLER_PATH+"] to ["+httpRemotingAddress+"]");
+    	HTTP_CONTROLLER_PATH = httpRemotingAddress;
+    }
 
+    if(nativeRemotingAddress != null && !nativeRemotingAddress.trim().equalsIgnoreCase(NATIVE_CONTROLLER_PATH)) {
+    	logger.branch(Type.INFO, "Changing default NATIVE_CONTROLLER_PATH property from ["+NATIVE_CONTROLLER_PATH+"] to ["+nativeRemotingAddress+"]");
+    	NATIVE_CONTROLLER_PATH = nativeRemotingAddress;
+    }
+
+    
     CommandContext ctx = null;
     try {
       // Create command context
@@ -168,10 +204,8 @@ public class JBossServletContainerAdaptor extends ServletContainer {
   private void attemptCommandContextConnection(final int maxRetries)
           throws UnableToCompleteException {
 
-    final String[] controllers = new String[] {
-        HTTP_CONTROLLER_PATH,
-        NATIVE_CONTROLLER_PATH
-    };
+    String[] controllers = new String[] { HTTP_CONTROLLER_PATH,  NATIVE_CONTROLLER_PATH  };
+    
     final String[] protocols = new String[controllers.length];
     for (int i = 0; i < controllers.length; i++) {
       protocols[i] = controllers[i].split(":", 2)[0];

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/JBossLauncher.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/JBossLauncher.java
@@ -39,9 +39,8 @@ public class JBossLauncher extends ServletContainerLauncher {
   private final String JBOSS_JAVA_OPTS_PROPERTY = "errai.jboss.javaopts";
   private final String TMP_CONFIG_FILE = "standalone-errai-dev.xml";
   
-  // Added 02/13/2016
-  private final String JBOSS_HTTP_REMOTING_ADDRESS     = "errai.jboss.httpremotingaddress";
-  private final String JBOSS_NATIVE_REMOTING_ADDRESS  = "errai.jboss.nativeremotingaddress";
+  private final String JBOSS_HTTP_REMOTING_ADDRESS = "errai.jboss.httpremotingaddress";
+  private final String JBOSS_NATIVE_REMOTING_ADDRESS = "errai.jboss.nativeremotingaddress";
 
   private StackTreeLogger logger;
 
@@ -52,14 +51,13 @@ public class JBossLauncher extends ServletContainerLauncher {
     logger.branch(Type.INFO, "Server launcher starting..");
 
     // Get properties
-    final String DEBUG_PORT 		     = System.getProperty(JBOSS_DEBUG_PORT_PROPERTY, "8001");
-    final String TEMPLATE_CONFIG_FILE    = System.getProperty(TEMPLATE_CONFIG_FILE_PROPERTY, "standalone-full.xml");
+    final String DEBUG_PORT = System.getProperty(JBOSS_DEBUG_PORT_PROPERTY, "8001");
+    final String TEMPLATE_CONFIG_FILE = System.getProperty(TEMPLATE_CONFIG_FILE_PROPERTY, "standalone-full.xml");
     final String CLASS_HIDING_JAVA_AGENT = System.getProperty(CLASS_HIDING_JAVA_AGENT_PROPERTY);
     String JAVA_OPTS = System.getProperty(JBOSS_JAVA_OPTS_PROPERTY, "");
     
-    // Added new properties to allow overriding of default ones.
-    final String HTTP_REMOTING_ADDRESS      =System.getProperty(JBOSS_HTTP_REMOTING_ADDRESS, "http-remoting://localhost:9990");
-    final String NATIVE_REMOTING_ADDRESS    =System.getProperty(JBOSS_NATIVE_REMOTING_ADDRESS, "remote://localhost:9999");
+    final String HTTP_REMOTING_ADDRESS = System.getProperty(JBOSS_HTTP_REMOTING_ADDRESS, "http-remoting://localhost:9990");
+    final String NATIVE_REMOTING_ADDRESS = System.getProperty(JBOSS_NATIVE_REMOTING_ADDRESS, "remote://localhost:9999");
 
     final String jbossHome = JBossUtil.getJBossHome(logger);
     validateClassHidingJavaAgent(CLASS_HIDING_JAVA_AGENT);
@@ -68,7 +66,7 @@ public class JBossLauncher extends ServletContainerLauncher {
       createTempConfigFile(TEMPLATE_CONFIG_FILE, TMP_CONFIG_FILE, jbossHome, port);
       logger.log(Type.INFO,
               String.format("Created temporary config file %s, copied from %s.", TMP_CONFIG_FILE, TEMPLATE_CONFIG_FILE));
-    }
+    } 
     catch (IOException e) {
       logger.log(
               Type.ERROR,

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/JBossLauncher.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/JBossLauncher.java
@@ -38,6 +38,10 @@ public class JBossLauncher extends ServletContainerLauncher {
   private final String CLASS_HIDING_JAVA_AGENT_PROPERTY = "errai.jboss.javaagent.path";
   private final String JBOSS_JAVA_OPTS_PROPERTY = "errai.jboss.javaopts";
   private final String TMP_CONFIG_FILE = "standalone-errai-dev.xml";
+  
+  // Added 02/13/2016
+  private final String JBOSS_HTTP_REMOTING_ADDRESS     = "errai.jboss.httpremotingaddress";
+  private final String JBOSS_NATIVE_REMOTING_ADDRESS  = "errai.jboss.nativeremotingaddress";
 
   private StackTreeLogger logger;
 
@@ -45,13 +49,17 @@ public class JBossLauncher extends ServletContainerLauncher {
   public ServletContainer start(TreeLogger treeLogger, int port, File appRootDir) throws BindException, Exception {
     logger = new StackTreeLogger(treeLogger);
 
-    logger.branch(Type.INFO, "Starting launcher...");
+    logger.branch(Type.INFO, "JBoss / WildFly launcher starting..");
 
     // Get properties
-    final String DEBUG_PORT = System.getProperty(JBOSS_DEBUG_PORT_PROPERTY, "8001");
-    final String TEMPLATE_CONFIG_FILE = System.getProperty(TEMPLATE_CONFIG_FILE_PROPERTY, "standalone-full.xml");
+    final String DEBUG_PORT 		     = System.getProperty(JBOSS_DEBUG_PORT_PROPERTY, "8001");
+    final String TEMPLATE_CONFIG_FILE    = System.getProperty(TEMPLATE_CONFIG_FILE_PROPERTY, "standalone-full.xml");
     final String CLASS_HIDING_JAVA_AGENT = System.getProperty(CLASS_HIDING_JAVA_AGENT_PROPERTY);
     String JAVA_OPTS = System.getProperty(JBOSS_JAVA_OPTS_PROPERTY, "");
+    
+    // Added new properties to allow overriding of default ones.
+    final String HTTP_REMOTING_ADDRESS      =System.getProperty(JBOSS_HTTP_REMOTING_ADDRESS, "http-remoting://localhost:9990");
+    final String NATIVE_REMOTING_ADDRESS    =System.getProperty(JBOSS_NATIVE_REMOTING_ADDRESS, "remote://localhost:9999");
 
     final String jbossHome = JBossUtil.getJBossHome(logger);
     validateClassHidingJavaAgent(CLASS_HIDING_JAVA_AGENT);
@@ -109,8 +117,9 @@ public class JBossLauncher extends ServletContainerLauncher {
     logger.branch(Type.INFO, "Creating servlet container controller...");
 
     try {
-      JBossServletContainerAdaptor controller = new JBossServletContainerAdaptor(port, appRootDir, JBossUtil.getDeploymentContext(),
-              logger.peek(), process);
+      
+      JBossServletContainerAdaptor controller = new JBossServletContainerAdaptor(port, appRootDir, JBossUtil.getDeploymentContext(), logger.peek(), process, HTTP_REMOTING_ADDRESS, NATIVE_REMOTING_ADDRESS);
+      
       logger.log(Type.INFO, "Controller created");
       logger.unbranch();
       return controller;

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/JBossLauncher.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/JBossLauncher.java
@@ -49,7 +49,7 @@ public class JBossLauncher extends ServletContainerLauncher {
   public ServletContainer start(TreeLogger treeLogger, int port, File appRootDir) throws BindException, Exception {
     logger = new StackTreeLogger(treeLogger);
 
-    logger.branch(Type.INFO, "JBoss / WildFly launcher starting..");
+    logger.branch(Type.INFO, "Server launcher starting..");
 
     // Get properties
     final String DEBUG_PORT 		     = System.getProperty(JBOSS_DEBUG_PORT_PROPERTY, "8001");


### PR DESCRIPTION
Added two properties errai.jboss.httpremotingaddress and errai.jboss.nativeremotingaddress to ovverride remoting addresses - may be useful if for any reason one needs to bind wildfly instance to different remoting port than 9999 and 9990.

