### PR TITLE
Add missing cdi-client for cdi-server tests

### DIFF
--- a/errai-cdi/errai-cdi-client/src/main/java/org/jboss/errai/enterprise/client/cdi/events/BusReadyEvent.java
+++ b/errai-cdi/errai-cdi-client/src/main/java/org/jboss/errai/enterprise/client/cdi/events/BusReadyEvent.java
@@ -16,7 +16,6 @@
 
 package org.jboss.errai.enterprise.client.cdi.events;
 
-import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 
 /**

--- a/errai-cdi/errai-cdi-server/pom.xml
+++ b/errai-cdi/errai-cdi-server/pom.xml
@@ -102,6 +102,11 @@
         <dependency>
           <groupId>org.jboss.errai</groupId>
           <artifactId>errai-cdi-client</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.errai</groupId>
+          <artifactId>errai-cdi-client</artifactId>
           <type>test-jar</type>
           <scope>test</scope>
         </dependency>


### PR DESCRIPTION
@csadilek, @mbarkley please take a look. This is currently breaking all PR builds as we build Errai from sources.