### PR TITLE
Upgrade Guava from 19.0.0.jbossorg-1 to 19.0.0.jbossorg-2

### DIFF
--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -50,7 +50,7 @@
     <el.api.version>2.2</el.api.version>
     <exec.maven.plugin.version>1.2.1</exec.maven.plugin.version>
     <gmaven.mojo.version>1.5</gmaven.mojo.version>
-    <guava.version>19.0.0.jbossorg-1</guava.version>
+    <guava.version>19.0.0.jbossorg-2</guava.version>
     <guice.version>3.0</guice.version>
     <gwt.ajaxloader.version>1.1.0</gwt.ajaxloader.version>
     <gwt.exporter.version>2.3.0</gwt.exporter.version>


### PR DESCRIPTION
To align with Guava version KIE Workbench is now using.