### PR TITLE
PLANNER-579: Reduce WARN messages during startup

### DIFF
--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
@@ -85,10 +85,16 @@ public class EmbeddedWildFlyLauncher extends ServletContainerLauncher {
   public ServletContainer start(final TreeLogger treeLogger, final int port, final File appRootDir) throws BindException, Exception {
     logger = new StackTreeLogger(treeLogger);
     try {
-      System.setProperty("jboss.http.port", "" + port);
-
       final String jbossHome = JBossUtil.getJBossHome(logger);
       final String[] cmdArgs = JBossUtil.getCommandArguments(logger);
+
+      System.setProperty("jboss.http.port", "" + port);
+
+      File cliConfigFile = new File(jbossHome, JBossUtil.CLI_CONFIGURATION_FILE);
+      if (cliConfigFile.exists()) {
+        System.setProperty("jboss.cli.config", cliConfigFile.getAbsolutePath());
+      }
+
       final StandaloneServer embeddedWildFly = EmbeddedServerFactory.create(jbossHome, null, null, new String[0], cmdArgs);
       embeddedWildFly.start();
 

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/util/JBossUtil.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/util/JBossUtil.java
@@ -33,6 +33,7 @@ public class JBossUtil {
   private static final String CMD_ARGS_PROPERTY = "errai.jboss.args";
   public static final String USERS_PROPERTY_FILE = "application-users.properties";
   public static final String ROLES_PROPERTY_FILE = "application-roles.properties";
+  public static final String CLI_CONFIGURATION_FILE = "bin" + File.separator + "jboss-cli.xml";
   public static final String STANDALONE_CONFIGURATION = "standalone" + File.separator + "configuration";
 
   public static String getJBossHome(final StackTreeLogger logger) throws UnableToCompleteException {

--- a/errai-security/errai-security-server/src/main/java/org/jboss/errai/security/server/SecurityAnnotationExtension.java
+++ b/errai-security/errai-security-server/src/main/java/org/jboss/errai/security/server/SecurityAnnotationExtension.java
@@ -23,6 +23,7 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.AnnotatedMethod;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.WithAnnotations;
 
 import org.apache.deltaspike.core.util.metadata.builder.AnnotatedTypeBuilder;
 import org.jboss.errai.security.shared.api.annotation.RestrictedAccess;
@@ -36,7 +37,7 @@ import org.jboss.errai.security.shared.api.annotation.RestrictedAccess;
  */
 public class SecurityAnnotationExtension implements Extension {
 
-  public void addParameterLogger(@Observes ProcessAnnotatedType<?> processAnnotatedType) {
+  public void addParameterLogger(@Observes @WithAnnotations( RestrictedAccess.class ) ProcessAnnotatedType<?> processAnnotatedType) {
     final Class<?>[] interfaces = processAnnotatedType.getAnnotatedType().getJavaClass().getInterfaces();
 
     for (Class<?> anInterface : interfaces) {


### PR DESCRIPTION
Fixes warnings when starting OptaPlanner WB in Super Dev Mode

WARN  [org.jboss.weld.Event] WELD-000411: Observer method [BackedAnnotatedMethod] public org.jboss.errai.security.server.SecurityAnnotationExtension.addParameterLogger(@Observes ProcessAnnotatedType<Object>) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.

WARN: can't find jboss-cli.xml. Using default configuration values.
