### PR TITLE
Fixing properties parser to read properties values ending with '\:' or '\=' correctly

### DIFF
--- a/errai-common/src/main/java/org/jboss/errai/common/client/util/Properties.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/util/Properties.java
@@ -161,6 +161,12 @@ public class Properties {
               case 'n':
                 state.value.append('\n');
                 break;
+              case '=':
+                state.value.append('=');
+                break;
+              case ':':
+                state.value.append(':');
+                break;
               case '\\':
                 state.value.append('\\');
                 break;

--- a/errai-common/src/test/java/org/jboss/errai/common/client/util/PropertiesTest.java
+++ b/errai-common/src/test/java/org/jboss/errai/common/client/util/PropertiesTest.java
@@ -159,4 +159,24 @@ public class PropertiesTest {
     assertEquals(2, props.size());
   }
 
+  @Test
+  public void parseValueEndingWithEscapedEquals() {
+    final String data = "key1=value1\\=\nkey2=value2";
+    final Map<String, String> props = Properties.load(data);
+
+    assertEquals("value1=", props.get("key1"));
+    assertEquals("value2", props.get("key2"));
+    assertEquals(2, props.size());
+  }
+
+  @Test
+  public void parseValueEndingWithEscapedTwoPoints() {
+    final String data = "key1=value1\\:\nkey2=value2";
+    final Map<String, String> props = Properties.load(data);
+
+    assertEquals("value1:", props.get("key1"));
+    assertEquals("value2", props.get("key2"));
+    assertEquals(2, props.size());
+  }
+
 }


### PR DESCRIPTION
Bug example: 

Given a properties file:

    key1=value1\:
    key2=value2

The parser would just return one property with key "key1" and value "value1key2=value2" (ignoring the EOL).