### PR TITLE
adding support for copying mgmt users and group if provided 

### DIFF
--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
@@ -121,18 +121,32 @@ public class EmbeddedWildFlyLauncher extends ServletContainerLauncher {
    * roles for development mode.
    */
   private void prepareUsersAndRoles(final String jbossHome) {
-    InputStream usersStream =
-            Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.USERS_PROPERTY_FILE);
+    InputStream appUsersStream =
+            Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.APP_USERS_PROPERTY_FILE);
 
-    if (usersStream != null) {
-      processPropertiesFile(JBossUtil.USERS_PROPERTY_FILE, jbossHome, usersStream, true);
+    if (appUsersStream != null) {
+      processPropertiesFile(JBossUtil.APP_USERS_PROPERTY_FILE, jbossHome, appUsersStream, true);
     }
 
-    InputStream rolesStream =
-            Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.ROLES_PROPERTY_FILE);
+    InputStream appRolesStream =
+            Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.APP_ROLES_PROPERTY_FILE);
 
-    if (rolesStream != null) {
-      processPropertiesFile(JBossUtil.ROLES_PROPERTY_FILE, jbossHome, rolesStream, false);
+    if (appRolesStream != null) {
+      processPropertiesFile(JBossUtil.APP_ROLES_PROPERTY_FILE, jbossHome, appRolesStream, false);
+    }
+    
+    InputStream mgmtUsersStream =
+            Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.MGMT_USERS_PROPERTY_FILE);
+
+    if (mgmtUsersStream != null) {
+      processPropertiesFile(JBossUtil.MGMT_USERS_PROPERTY_FILE, jbossHome, mgmtUsersStream, true);
+    }
+
+    InputStream mgmtGroupsStream =
+            Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.MGMT_GROUPS_PROPERTY_FILE);
+
+    if (mgmtGroupsStream != null) {
+      processPropertiesFile(JBossUtil.MGMT_GROUPS_PROPERTY_FILE, jbossHome, mgmtGroupsStream, false);
     }
   }
 

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/util/JBossUtil.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/util/JBossUtil.java
@@ -31,8 +31,10 @@ public class JBossUtil {
   private static final String APP_CONTEXT_PROPERTY = "errai.dev.context";
   private static final String JBOSS_HOME_PROPERTY = "errai.jboss.home";
   private static final String CMD_ARGS_PROPERTY = "errai.jboss.args";
-  public static final String USERS_PROPERTY_FILE = "application-users.properties";
-  public static final String ROLES_PROPERTY_FILE = "application-roles.properties";
+  public static final String APP_USERS_PROPERTY_FILE = "application-users.properties";
+  public static final String APP_ROLES_PROPERTY_FILE = "application-roles.properties";
+  public static final String MGMT_USERS_PROPERTY_FILE = "mgmt-users.properties";
+  public static final String MGMT_GROUPS_PROPERTY_FILE = "mgmt-groups.properties";
   public static final String CLI_CONFIGURATION_FILE = "bin" + File.separator + "jboss-cli.xml";
   public static final String STANDALONE_CONFIGURATION = "standalone" + File.separator + "configuration";
 


### PR DESCRIPTION
to the wildfly instance.

@csadilek @mbarkley can you guys let me know if we need a test for this. If so, can you point me out what test is checking the correct behavior for the normal App/Roles files? 

These changes are required to automatically create a users for the wildfly instance that is running in dev mode. The configuration files will be picked up (as the app/roles files) from the src/main/resources of the project starting GWT dev mode. 