### PR TITLE
Exclude slf4j-simple from lesscss

### DIFF
--- a/errai-ui/pom.xml
+++ b/errai-ui/pom.xml
@@ -119,6 +119,12 @@
     <dependency>
       <groupId>org.lesscss</groupId>
       <artifactId>lesscss</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <!-- Replacement for commons-logging-api excluded from the above org.apache.stanbol.enhancer.engines.htmlextractor -->


### PR DESCRIPTION
```lesscss``` brings in dependency ```org.slf4j:slf4j-simple``` which causes upstream build errors (e.g. ```uberfire/uberfire-showcase/uberfire-client-webapp``` where Maven Enforcer Plugins fail the build should a duplicate class implementation be detected). It should be customary for end-user applications to specify logging implementations not transitive libraries.