### PR TITLE
ERRAI-1016: Duplicate method getContext() in generated Proxy error

### DIFF
--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/AbstractContext.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/AbstractContext.java
@@ -228,7 +228,7 @@ public abstract class AbstractContext implements Context {
 
   @Override
   public boolean isManaged(final Object ref) {
-    return (ref instanceof Proxy && ((Proxy<?>) ref).getContext() == this)
+    return (ref instanceof Proxy && ((Proxy<?>) ref).getProxyContext() == this)
             || factoriesByCreatedInstances.containsKey(ref);
   }
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/Proxy.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/Proxy.java
@@ -51,12 +51,12 @@ public interface Proxy<T> extends WrappedPortable {
    *
    * @param context The context associated with the {@link Factory} that created this proxy.
    */
-  void setContext(Context context);
+  void setProxyContext( Context context );
 
   /**
-   * @return The context set by {@link #setContext(Context)}.
+   * @return The context set by {@link #setProxyContext(Context)}.
    */
-  Context getContext();
+  Context getProxyContext();
 
   /**
    * Called once after {@link #setInstance(Object)} is called.

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/ProxyHelper.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/ProxyHelper.java
@@ -50,10 +50,10 @@ public interface ProxyHelper<T> {
    *
    * @param context The context associated with the containing {@link Proxy}.
    */
-  void setContext(Context context);
+  void setProxyContext( Context context );
 
   /**
-   * @return The {@link Context} previously set by {@link #setContext(Context)}.
+   * @return The {@link Context} previously set by {@link #setProxyContext(Context)}.
    */
-  Context getContext();
+  Context getProxyContext();
 }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/ProxyHelperImpl.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/container/ProxyHelperImpl.java
@@ -62,7 +62,7 @@ public class ProxyHelperImpl<T> implements ProxyHelper<T> {
   }
 
   @Override
-  public void setContext(final Context context) {
+  public void setProxyContext( final Context context ) {
     if (this.context != null) {
       throw new RuntimeException("Context can only be set once.");
     }
@@ -71,7 +71,7 @@ public class ProxyHelperImpl<T> implements ProxyHelper<T> {
   }
 
   @Override
-  public Context getContext() {
+  public Context getProxyContext() {
     assertContextIsSet();
 
     return context;

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/bootstrapper/AbstractBodyGenerator.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/bootstrapper/AbstractBodyGenerator.java
@@ -162,7 +162,7 @@ public abstract class AbstractBodyGenerator implements FactoryBodyGenerator {
               .append(declareFinalVariable("proxyImpl",
                       parameterizedAs(Proxy.class, typeParametersOf(injectable.getInjectedType())),
                       proxyInstanceStmt))
-              .append(loadVariable("proxyImpl").invoke("setContext", loadVariable("context")))
+              .append(loadVariable("proxyImpl").invoke("setProxyContext", loadVariable("context")))
               .append(loadVariable("proxyImpl").returnValue()).finish();
     }
   }
@@ -498,16 +498,16 @@ public abstract class AbstractBodyGenerator implements FactoryBodyGenerator {
   }
 
   private void implementSetContext(final ClassStructureBuilder<?> proxyImpl, final Injectable injectable) {
-    proxyImpl.publicMethod(void.class, "setContext", finalOf(Context.class, "context"))
+    proxyImpl.publicMethod(void.class, "setProxyContext", finalOf(Context.class, "context"))
              .body()
-             .append(loadVariable("proxyHelper").invoke("setContext", loadVariable("context")))
+             .append(loadVariable("proxyHelper").invoke("setProxyContext", loadVariable("context")))
              .finish();
   }
 
   private void implementGetContext(final ClassStructureBuilder<?> proxyImpl, final Injectable injectable) {
-    proxyImpl.publicMethod(Context.class, "getContext")
+    proxyImpl.publicMethod(Context.class, "getProxyContext")
              .body()
-             .append(loadVariable("proxyHelper").invoke("getContext").returnValue())
+             .append(loadVariable("proxyHelper").invoke("getProxyContext").returnValue())
              .finish();
   }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/ERRAI-1016

This PR simply renames the offending methods... I guess, ideally, Errai should use some form of internal method name representation to avoid/minimise conflicts in the future; but I'll leave that for @mbarkley to consider.