### PR TITLE
Adding NavigationControl support to @PageShowing

### DIFF
--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
@@ -135,11 +135,6 @@ public class Navigation {
   private boolean locked = false;
 
   /**
-   * Indicates that a navigation request is in hiding phase.
-   */
-  private boolean hiding = false;
-
-  /**
    * Queued navigation requests which could not handled immediately.
    */
   private final Queue<Request> queuedRequests = new LinkedList<>();
@@ -451,7 +446,6 @@ public class Navigation {
     final NavigationControl control = new NavigationControl(Navigation.this, new Runnable() {
       @Override
       public void run() {
-        hiding = false;
         final Access<C> accessEvent = new AccessImpl<>();
 
         accessEvent.fireAsync(component, new LifecycleCallback() {
@@ -490,8 +484,7 @@ public class Navigation {
                 locked = true;
                 hideCurrentPage();
                 request.pageNode.pageShowing(component, request.state, showControl);
-              }
-              catch (Exception ex) {
+              } catch (Exception ex) {
                 locked = false;
                 throw ex;
               }
@@ -501,17 +494,16 @@ public class Navigation {
           }
         });
       }
+    }, new Runnable() {
+      @Override
+      public void run() {
+        hideCurrentPage();
+        setCurrentPage(null);
+      }
     });
 
-    if (!hiding && currentPage != null && currentWidget != null && currentComponent != null && currentWidget.asWidget() == navigatingContainer.getWidget()) {
-      hiding = true;
-      try {
-        currentPage.pageHiding(Factory.maybeUnwrapProxy(currentComponent), control);
-      }
-      catch (Exception ex) {
-        hiding = false;
-        throw ex;
-      }
+    if (currentPage != null && currentWidget != null && currentComponent != null && currentWidget.asWidget() == navigatingContainer.getWidget()) {
+      currentPage.pageHiding(Factory.maybeUnwrapProxy(currentComponent), control);
     } else {
       control.proceed();
     }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageShowing.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageShowing.java
@@ -16,6 +16,8 @@
 
 package org.jboss.errai.ui.nav.client.local;
 
+import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -41,6 +43,14 @@ import java.lang.annotation.Target;
  * not all history token key names are known at compile time, so
  * {@code @PageState} fields can't be declared to accept their values.
  * <p>
+ * The target method is permitted an optional parameter of type {@link NavigationControl}. If the
+ * parameter is present, the page navigation will not be carried out until
+ * {@link NavigationControl#proceed()} is invoked. This is useful for interrupting page navigation
+ * and then resuming at a later time (for example, to prompt the user to save their work before
+ * transitioning to a new page).
+ * <p>
+ * Page loading can be interrupted by calling {@link NavigationControl#redirect()}.
+ * This allows for page redirection rather than proceeding a pages navigation.
  * The target method's return type must be {@code void}.
  * <p>
  * The target method can have any access type: public, protected, default, or

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageShowing.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageShowing.java
@@ -45,11 +45,11 @@ import java.lang.annotation.Target;
  * <p>
  * The target method is permitted an optional parameter of type {@link NavigationControl}. If the
  * parameter is present, the page navigation will not be carried out until
- * {@link NavigationControl#proceed()} is invoked. This is useful for interrupting page navigation
- * and then resuming at a later time (for example, to prompt the user to save their work before
- * transitioning to a new page).
+ * {@link NavigationControl#proceed()} is invoked. This is useful for redirecting navigation before
+ * a page has been displayed, based on asynchronous logic (for example, to redirect to another page
+ * based on the result of an Errai RPC).
  * <p>
- * Page loading can be interrupted by calling {@link NavigationControl#redirect()}.
+ * Page loading can be interrupted by calling {@link NavigationControl#redirect(Class)}.
  * This allows for page redirection rather than proceeding a pages navigation.
  * The target method's return type must be {@code void}.
  * <p>

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/spi/PageNode.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/spi/PageNode.java
@@ -77,7 +77,7 @@ public interface PageNode<C> {
    * @param state
    *          the state of the page, parsed from the history token on the URL. Never null.
    */
-  public void pageShowing(C widget, HistoryToken state);
+  public void pageShowing(C widget, HistoryToken state, NavigationControl control);
 
   /**
    * Called by the framework when this page node was displayed in the navigation content panel.

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/NavigationTest.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/NavigationTest.java
@@ -423,19 +423,35 @@ public class NavigationTest extends AbstractErraiCDITest {
     delayTestFinish(5000);
   }
 
-  public void testNavigationControl() throws Exception {
+  /*public void testNavigationControl() throws Exception {
     final PageWithNavigationControl page = Factory.maybeUnwrapProxy(IOC.getBeanManager().lookupBean(PageWithNavigationControl.class)
             .getInstance());
 
     navigation.goTo(PageWithNavigationControl.class, ArrayListMultimap.<String, String> create());
+    page.showControl.proceed();
     assertEquals(PageWithNavigationControl.class, navigation.getCurrentPage().contentType());
 
     navigation.goTo(PageA.class, ArrayListMultimap.<String, String> create());
-    assertEquals(PageWithNavigationControl.class, navigation.getCurrentPage().contentType());
-
-    page.control.proceed();
+    page.hideControl.proceed();
     assertEquals(PageA.class, navigation.getCurrentPage().contentType());
   }
+
+  public void testNavigationControlRedirect() throws Exception {
+    final PageWithNavigationControl page = Factory.maybeUnwrapProxy(IOC.getBeanManager().lookupBean(PageWithNavigationControl.class)
+            .getInstance());
+
+    navigation.goTo(PageWithNavigationControl.class, ArrayListMultimap.<String, String> create());
+    page.showControl.redirect(PageA.class);
+    assertEquals(PageA.class, navigation.getCurrentPage().contentType());
+
+    navigation.goTo(PageWithNavigationControl.class, ArrayListMultimap.<String, String> create());
+    page.showControl.proceed();
+    assertEquals(PageWithNavigationControl.class, navigation.getCurrentPage().contentType());
+
+    navigation.goTo(PageA.class, ArrayListMultimap.<String, String> create());
+    page.hideControl.redirect(PageB.class);
+    assertEquals(PageB.class, navigation.getCurrentPage().contentType());
+  }*/
 
   /**
    * Give the bootstrapper time to attach the Navigation content panel to the RootPanel and then run a test.

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/NavigationTest.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/NavigationTest.java
@@ -423,7 +423,7 @@ public class NavigationTest extends AbstractErraiCDITest {
     delayTestFinish(5000);
   }
 
-  /*public void testNavigationControl() throws Exception {
+  public void testNavigationControl() throws Exception {
     final PageWithNavigationControl page = Factory.maybeUnwrapProxy(IOC.getBeanManager().lookupBean(PageWithNavigationControl.class)
             .getInstance());
 
@@ -451,7 +451,7 @@ public class NavigationTest extends AbstractErraiCDITest {
     navigation.goTo(PageA.class, ArrayListMultimap.<String, String> create());
     page.hideControl.redirect(PageB.class);
     assertEquals(PageB.class, navigation.getCurrentPage().contentType());
-  }*/
+  }
 
   /**
    * Give the bootstrapper time to attach the Navigation content panel to the RootPanel and then run a test.

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithNavigationControl.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithNavigationControl.java
@@ -18,8 +18,10 @@ package org.jboss.errai.ui.nav.client.local.testpages;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.jboss.errai.ui.nav.client.local.HistoryToken;
 import org.jboss.errai.ui.nav.client.local.Page;
 import org.jboss.errai.ui.nav.client.local.PageHiding;
+import org.jboss.errai.ui.nav.client.local.PageShowing;
 import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
 
 import com.google.gwt.user.client.ui.SimplePanel;
@@ -27,12 +29,18 @@ import com.google.gwt.user.client.ui.SimplePanel;
 @Page
 @ApplicationScoped
 public class PageWithNavigationControl extends SimplePanel {
-  
-  public NavigationControl control;
+
+  public NavigationControl showControl;
+  public NavigationControl hideControl;
+
+  @PageShowing
+  private void confirm(final HistoryToken historyToken, final NavigationControl control) {
+    this.showControl = control;
+  }
   
   @PageHiding
   private void confirm(final NavigationControl control) {
-    this.control = control;
+    this.hideControl = control;
   }
 
 }


### PR DESCRIPTION
A continuation of #215
This gives an opportunity for "gatekeeping" pages asynchronously.

```java
@PageShowing
void onShowing(HistoryToken historyToken, NavigationControl control) {
    myService.call(hasAccess -> {
        if(hasAccess) {
            // We have access, proceed with navigation.
            control.proceed();
        } else {
            // Interrupt navigation and redirect.
            // can perform any other tasks before redirecting.
            control.redirect(RedirectPage.class);
        }
    }).hasAccess(modelId, userId);
}
```

Tested and confirmed to work in @PageHiding methods too.
Includes tests for each feature.