### PR TITLE
ERRAI-1018: Support for javax.enterprise.inject.Typed

### DIFF
--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/bootstrapper/AbstractBodyGenerator.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/bootstrapper/AbstractBodyGenerator.java
@@ -36,6 +36,7 @@ import static org.jboss.errai.codegen.util.Stmt.try_;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -44,6 +45,7 @@ import java.util.Map.Entry;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Typed;
 import javax.inject.Named;
 import javax.inject.Qualifier;
 
@@ -713,8 +715,24 @@ public abstract class AbstractBodyGenerator implements FactoryBodyGenerator {
     final ConstructorBlockBuilder<?> con = bodyBlockBuilder.publicConstructor();
     con.callSuper(newObject);
 
-    final AbstractStatementBuilder assignableTypeArrayStmt = getAssignableTypesArrayStmt(injectable.getInjectedType());
-    con.append(loadVariable("handle").invoke("setAssignableTypes", assignableTypeArrayStmt));
+    final AbstractStatementBuilder assignableTypesArrayStmt =
+            injectable.getAnnotatedObject()
+            .map(annotated -> annotated.getAnnotation(Typed.class))
+            .map(typedAnno -> typedAnno.value())
+            .map(beanTypes -> {
+              if (Arrays.stream(beanTypes).anyMatch(type -> Object.class.equals(type))) {
+                return (Object[]) beanTypes;
+              }
+              else {
+                final Class<?>[] copyWithObject = Arrays.copyOf(beanTypes, beanTypes.length+1);
+                copyWithObject[beanTypes.length] = Object.class;
+                return (Object[]) copyWithObject;
+              }
+            })
+            .map(beanTypes -> newArray(Class.class).initialize(beanTypes))
+            .orElseGet(() -> getAssignableTypesArrayStmt(injectable.getInjectedType()));
+
+    con.append(loadVariable("handle").invoke("setAssignableTypes", assignableTypesArrayStmt));
 
     final org.jboss.errai.ioc.rebind.ioc.graph.api.Qualifier qualifier = injectable.getQualifier();
     if (!qualifier.isDefaultQualifier()) {

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/DependencyGraphBuilder.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/DependencyGraphBuilder.java
@@ -17,6 +17,8 @@
 package org.jboss.errai.ioc.rebind.ioc.graph.api;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.function.Predicate;
 
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -31,6 +33,7 @@ import org.jboss.errai.codegen.meta.MetaParameter;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.rebind.ioc.extension.IOCExtensionConfigurator;
 import org.jboss.errai.ioc.rebind.ioc.extension.builtin.LoggerFactoryIOCExtension;
+import org.jboss.errai.ioc.rebind.ioc.graph.impl.InjectableHandle;
 import org.jboss.errai.ioc.rebind.ioc.graph.impl.ResolutionPriority;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectableProvider;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.WiringElementType;
@@ -64,17 +67,21 @@ public interface DependencyGraphBuilder {
    *          The class of the injectable.
    * @param qualifier
    *          The {@link Qualifier} of the injectable.
+   * @param pathPredicate
+   *          Used to add restrictions on what dependencies are satisfied by the added injectable. This predicate is
+   *          called anytime the created injectable is a candidate for a dependency. The predicate argument is the
+   *          {@link InjectableHandle InjectableHandles} traversed in order to arrive at this injectable. If the
+   *          predicate returns false, the injectable does not satisfy a dependency.
    * @param literalScope
    *          The {@link Scope} of the injectable.
    * @param injectableType
    *          The kind of injectable (i.e. producer, provider, type, etc.).
    * @param wiringTypes
-   *          A collection of {@link WiringElementType wiring types} that this
-   *          injectable has.
+   *          A collection of {@link WiringElementType wiring types} that this injectable has.
    *
    * @return The newly added {@link Injectable}.
    */
-  Injectable addInjectable(MetaClass injectedType, Qualifier qualifier, Class<? extends Annotation> literalScope,
+  Injectable addInjectable(MetaClass injectedType, Qualifier qualifier, Predicate<List<InjectableHandle>> pathPredicate, Class<? extends Annotation> literalScope,
           InjectableType injectableType, WiringElementType... wiringTypes);
 
   /**
@@ -90,6 +97,11 @@ public interface DependencyGraphBuilder {
    *          The class of the injectable.
    * @param qualifier
    *          The {@link Qualifier} of the injectable.
+   * @param pathPredicate
+   *          Used to add restrictions on what dependencies are satisfied by the added injectable. This predicate is
+   *          called anytime the created injectable is a candidate for a dependency. The predicate argument is the
+   *          {@link InjectableHandle InjectableHandles} traversed in order to arrive at this injectable. If the
+   *          predicate returns false, the injectable does not satisfy a dependency.
    * @param literalScope
    *          The {@link Scope} of the injectable.
    * @param injectableType
@@ -100,7 +112,9 @@ public interface DependencyGraphBuilder {
    *
    * @return The newly added extension {@link Injectable}.
    */
-  Injectable addExtensionInjectable(MetaClass injectedType, Qualifier qualifier, InjectableProvider provider, WiringElementType... wiringTypes);
+  Injectable addExtensionInjectable(MetaClass injectedType, Qualifier qualifier,
+          Predicate<List<InjectableHandle>> pathPredicate, InjectableProvider provider,
+          WiringElementType... wiringTypes);
 
   /**
    * Create a dependency for a field injection point in a bean class.

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/Injectable.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/Injectable.java
@@ -18,10 +18,12 @@ package org.jboss.errai.ioc.rebind.ioc.graph.api;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Named;
 
+import org.jboss.errai.codegen.meta.HasAnnotations;
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.ioc.client.api.ContextualTypeProvider;
 import org.jboss.errai.ioc.client.api.LoadAsync;
@@ -43,6 +45,11 @@ public interface Injectable extends HasInjectableHandle {
    *         should return {@link Dependent}.
    */
   Class<? extends Annotation> getScope();
+
+  /**
+   * @return If available, the annotated object that is the source of this injectable.
+   */
+  Optional<HasAnnotations> getAnnotatedObject();
 
   /**
    * @return The name of this injectable if {@link Named} annotation was

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DefaultCustomFactoryInjectable.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DefaultCustomFactoryInjectable.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.ioc.rebind.ioc.bootstrapper.FactoryBodyGenerator;
+import org.jboss.errai.ioc.rebind.ioc.bootstrapper.IOCProcessor;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.CustomFactoryInjectable;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.InjectableType;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Qualifier;
@@ -36,7 +37,7 @@ public class DefaultCustomFactoryInjectable extends InjectableImpl implements Cu
   public DefaultCustomFactoryInjectable(final MetaClass type, final Qualifier qualifier, final String factoryName,
           final Class<? extends Annotation> literalScope, final Collection<WiringElementType> wiringTypes,
           final FactoryBodyGenerator generator) {
-    super(type, qualifier, factoryName, literalScope, InjectableType.ExtensionProvided, wiringTypes);
+    super(type, qualifier, IOCProcessor.ANY, factoryName, literalScope, InjectableType.ExtensionProvided, wiringTypes);
     this.generator = generator;
   }
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DependencyGraphBuilderImpl.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DependencyGraphBuilderImpl.java
@@ -44,6 +44,7 @@ import org.jboss.errai.codegen.meta.MetaField;
 import org.jboss.errai.codegen.meta.MetaMethod;
 import org.jboss.errai.codegen.meta.MetaParameter;
 import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.ioc.rebind.ioc.bootstrapper.IOCProcessor;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraph;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Injectable;
@@ -69,7 +70,6 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
   private final QualifierFactory qualFactory;
   private final Map<InjectableHandle, InjectableReference> injectableReferences = new HashMap<>();
   private final Multimap<MetaClass, InjectableReference> directInjectableReferencesByAssignableTypes = HashMultimap.create();
-  private final Multimap<MetaClass, InjectableImpl> exactTypeInjectablesByType = HashMultimap.create();
   private final Map<String, Injectable> injectablesByName = new HashMap<>();
   private final List<InjectableImpl> specializations = new ArrayList<>();
   private final FactoryNameGenerator nameGenerator = new FactoryNameGenerator();
@@ -81,9 +81,10 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
   }
 
   @Override
-  public Injectable addInjectable(final MetaClass injectedType, final Qualifier qualifier, final Class<? extends Annotation> literalScope,
+  public Injectable addInjectable(final MetaClass injectedType, final Qualifier qualifier,
+          final Predicate<List<InjectableHandle>> pathPredicate, final Class<? extends Annotation> literalScope,
           final InjectableType injectableType, final WiringElementType... wiringTypes) {
-    final InjectableImpl injectable = new InjectableImpl(injectedType, qualifier,
+    final InjectableImpl injectable = new InjectableImpl(injectedType, qualifier, pathPredicate,
             nameGenerator.generateFor(injectedType, qualifier, injectableType), literalScope, injectableType,
             Arrays.asList(wiringTypes));
 
@@ -100,11 +101,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     if (injectable.wiringTypes.contains(WiringElementType.Specialization)) {
       specializations.add(injectable);
     }
-    if (injectable.wiringTypes.contains(WiringElementType.ExactTypeMatching)) {
-      exactTypeInjectablesByType.put(injectable.type.getErased(), injectable);
-    } else {
-      linkDirectInjectableReference(injectable);
-    }
+    linkDirectInjectableReference(injectable);
 
     return injectable;
   }
@@ -119,8 +116,9 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   @Override
   public Injectable addExtensionInjectable(final MetaClass injectedType, final Qualifier qualifier,
-          final InjectableProvider provider, final WiringElementType... wiringTypes) {
-    final InjectableImpl injectable = new ExtensionInjectable(injectedType, qualifier,
+          final Predicate<List<InjectableHandle>> pathPredicate, final InjectableProvider provider,
+          final WiringElementType... wiringTypes) {
+    final InjectableImpl injectable = new ExtensionInjectable(injectedType, qualifier, pathPredicate,
             nameGenerator.generateFor(injectedType, qualifier, InjectableType.Extension), null,
             InjectableType.Extension, Arrays.asList(wiringTypes), provider);
     return registerNewInjectable(injectable);
@@ -180,7 +178,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
   }
 
   private Collection<Validator> createValidators() {
-    final Collection<Validator> validators = new ArrayList<Validator>();
+    final Collection<Validator> validators = new ArrayList<>();
     validators.add(new CycleValidator());
     if (async) {
       validators.add(new AsyncValidator());
@@ -227,7 +225,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     /*
      * Need to copy this because the call to lookupInjectableReference may modify the collection.
      */
-    final Collection<InjectableReference> directInjectableReferencesOfProducedType = new ArrayList<InjectableReference>(
+    final Collection<InjectableReference> directInjectableReferencesOfProducedType = new ArrayList<>(
             directInjectableReferencesByAssignableTypes.get(producedType));
     for (final InjectableReference injectable : directInjectableReferencesOfProducedType) {
       if (injectable.type.equals(producedType)) {
@@ -285,7 +283,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
   }
 
   private void removeLinksToProducedTypes(final InjectableImpl specialized, final Set<InjectableImpl> toBeRemoved) {
-    final Collection<InjectableReference> producedReferences = new ArrayList<InjectableReference>();
+    final Collection<InjectableReference> producedReferences = new ArrayList<>();
     for (final MetaMethod method : specialized.type.getDeclaredMethodsAnnotatedWith(Produces.class)) {
       producedReferences.add(lookupInjectableReference(method.getReturnType(), qualFactory.forSource(method)));
     }
@@ -313,7 +311,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   private void validateInjectables() {
     logger.debug("Validating dependency graph...");
-    final Collection<String> problems = new ArrayList<String>();
+    final Collection<String> problems = new ArrayList<>();
     final Collection<Validator> validators = createValidators();
     for (final Injectable injectable : injectablesByName.values()) {
       for (final Validator validator : validators) {
@@ -329,8 +327,8 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   private void removeUnreachableInjectables(final ReachabilityStrategy strategy) {
     logger.debug("Removing unreachable injectables from dependency graph using {} strategy.", strategy);
-    final Set<String> reachableNames = new HashSet<String>();
-    final Queue<Injectable> processingQueue = new LinkedList<Injectable>();
+    final Set<String> reachableNames = new HashSet<>();
+    final Queue<Injectable> processingQueue = new LinkedList<>();
     final Predicate<Injectable> reachabilityRoot = reachabilityRootPredicate(strategy);
     for (final Injectable injectable : injectablesByName.values()) {
       if (reachabilityRoot.test(injectable)
@@ -371,10 +369,10 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   private void resolveDependencies() {
     logger.debug("Resolving dependencies for {} injectables...", injectablesByName.size());
-    final Set<Injectable> visited = new HashSet<Injectable>();
-    final Set<String> transientInjectableNames = new HashSet<String>();
-    final List<String> dependencyProblems = new ArrayList<String>();
-    final Map<String, Injectable> customProvidedInjectables = new IdentityHashMap<String, Injectable>();
+    final Set<Injectable> visited = new HashSet<>();
+    final Set<String> transientInjectableNames = new HashSet<>();
+    final List<String> dependencyProblems = new ArrayList<>();
+    final Map<String, Injectable> customProvidedInjectables = new IdentityHashMap<>();
 
     for (final Injectable injectable : injectablesByName.values()) {
       if (injectable.isExtension()) {
@@ -404,12 +402,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     }
 
     logger.trace("Resolving dependency: {}", dep);
-    final Multimap<ResolutionPriority, InjectableImpl> resolvedByPriority = HashMultimap.create();
-    final Queue<InjectableReference> resolutionQueue = new LinkedList<InjectableReference>();
-    resolutionQueue.add(dep.injectable);
-    resolutionQueue.add(addMatchingExactTypeInjectables(dep.injectable));
-
-    processResolutionQueue(resolutionQueue, resolvedByPriority);
+    final Multimap<ResolutionPriority, InjectableImpl> resolvedByPriority = traverseLinks(dep.injectable);
 
     final Iterable<ResolutionPriority> priorities;
     final boolean reportProblems;
@@ -428,7 +421,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
         final Collection<InjectableImpl> resolved = resolvedByPriority.get(priority);
         if (resolved.size() > 1) {
           if (reportProblems) {
-            problems.add(GraphUtil.ambiguousDependencyMessage(dep, depOwner, new ArrayList<InjectableImpl>(resolved)));
+            problems.add(GraphUtil.ambiguousDependencyMessage(dep, depOwner, new ArrayList<>(resolved)));
           }
 
           return null;
@@ -461,7 +454,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     Injectable injectable = resolved.iterator().next();
     if (injectable.isExtension()) {
       final ExtensionInjectable providedInjectable = (ExtensionInjectable) injectable;
-      final Collection<Injectable> otherResolvedInjectables = new ArrayList<Injectable>(resolvedByPriority.values());
+      final Collection<Injectable> otherResolvedInjectables = new ArrayList<>(resolvedByPriority.values());
       otherResolvedInjectables.remove(injectable);
 
       final InjectionSite site = new InjectionSite(depOwner.getInjectedType(), dep, otherResolvedInjectables);
@@ -473,34 +466,39 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     return injectable;
   }
 
-  private InjectableReference addMatchingExactTypeInjectables(final InjectableReference depInjectable) {
-    final InjectableReference exactTypeLinker = new InjectableReference(depInjectable.type, depInjectable.qualifier);
-    for (final InjectableImpl candidate : exactTypeInjectablesByType.get(depInjectable.type.getErased())) {
-      if (GraphUtil.candidateSatisfiesInjectable(depInjectable, candidate, !candidate.isContextual())) {
-        exactTypeLinker.linked.add(candidate);
-      }
-    }
-
-    return exactTypeLinker;
-  }
-
-  private void processResolutionQueue(final Queue<InjectableReference> resolutionQueue,
-          final Multimap<ResolutionPriority, InjectableImpl> resolvedByPriority) {
-    logger.trace("Processing resolution queue with {} initial references...", resolutionQueue.size());
+  private Multimap<ResolutionPriority, InjectableImpl> traverseLinks(final InjectableReference dep) {
+    final Multimap<ResolutionPriority, InjectableImpl> resolvedByPriority = HashMultimap.create();
+    final LinkedList<InjectableHandle> handleStack = new LinkedList<>();
+    final LinkedList<Iterator<InjectableBase>> linkStack = new LinkedList<>();
+    handleStack.addLast(dep.getHandle());
+    linkStack.addLast(dep.linked.iterator());
     do {
-      final InjectableReference cur = resolutionQueue.poll();
-      logger.trace("Processing links of reference: {}", cur);
-      for (final InjectableBase link : cur.linked) {
+      final Iterator<InjectableBase> iter = linkStack.getLast();
+      if (iter.hasNext()) {
+        final InjectableBase link = iter.next();
         if (link instanceof InjectableReference) {
-          logger.trace("Adding linked reference to resolution queue: {}", link);
-          resolutionQueue.add((InjectableReference) link);
+          logger.trace("Adding linked reference to resolution stack: {}", link);
+          handleStack.addLast(link.getHandle());
+          linkStack.addLast(((InjectableReference) link).linked.iterator());
         } else if (link instanceof InjectableImpl) {
-          logger.trace("Adding linked injectable to resolution results: {}", link);
-          resolvedByPriority.put(getMatchingPriority((InjectableImpl) link), (InjectableImpl) link);
+          final InjectableImpl resolvedInjectable = (InjectableImpl) link;
+          if (resolvedInjectable.pathPredicate.test(handleStack)) {
+            logger.trace("Adding linked injectable to resolution results: {}", link);
+            resolvedByPriority.put(getMatchingPriority(resolvedInjectable), resolvedInjectable);
+          }
+          else {
+            logger.trace("Rejecting linked injectable to from resolution results based on path predicate: {}", link);
+          }
         }
       }
-    } while (resolutionQueue.size() > 0);
-    logger.trace("Finished processing resolution queue. Resolved {} injectables.", resolvedByPriority.size());
+      else {
+        handleStack.removeLast();
+        linkStack.removeLast();
+      }
+    } while (!linkStack.isEmpty());
+    logger.trace("Finished processing resolution stack. Resolved {} injectables.", resolvedByPriority.size());
+
+    return resolvedByPriority;
   }
 
   private Injectable getRootDisabledInjectable(Injectable inj, final Collection<String> problems,
@@ -544,8 +542,8 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   private InjectableReference createStaticMemberInjectable(final MetaClass producerType, final MetaClassMember member) {
     final InjectableReference retVal = new InjectableReference(producerType, qualFactory.forUniversallyQualified());
-    retVal.resolution = new InjectableImpl(producerType, qualFactory.forUniversallyQualified(), "",
-            ApplicationScoped.class, InjectableType.Static, Collections.<WiringElementType>emptyList());
+    retVal.resolution = new InjectableImpl(producerType, qualFactory.forUniversallyQualified(), IOCProcessor.ANY, "",
+            ApplicationScoped.class, InjectableType.Static, Collections.<WiringElementType> emptyList());
 
     return retVal;
   }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/ExtensionInjectable.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/ExtensionInjectable.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder;
@@ -35,13 +37,13 @@ import org.jboss.errai.ioc.rebind.ioc.injector.api.WiringElementType;
  */
 class ExtensionInjectable extends InjectableImpl {
 
-  final Collection<InjectionSite> injectionSites = new ArrayList<InjectionSite>();
+  final Collection<InjectionSite> injectionSites = new ArrayList<>();
   final InjectableProvider provider;
 
-  ExtensionInjectable(final MetaClass type, final Qualifier qualifier, final String factoryName,
-          final Class<? extends Annotation> literalScope, final InjectableType injectorType,
+  ExtensionInjectable(final MetaClass type, final Qualifier qualifier, final Predicate<List<InjectableHandle>> pathPredicate,
+          final String factoryName, final Class<? extends Annotation> literalScope, final InjectableType injectorType,
           final Collection<WiringElementType> wiringTypes, final InjectableProvider provider) {
-    super(type, qualifier, factoryName, literalScope, injectorType, wiringTypes);
+    super(type, qualifier, pathPredicate, factoryName, literalScope, injectorType, wiringTypes);
     this.provider = provider;
   }
 

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/QualForProducedTypeBean.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/QualForProducedTypeBean.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.tests.wiring.client.res;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Retention(RUNTIME)
+@Target({ TYPE, FIELD, METHOD, PARAMETER })
+@Qualifier
+public @interface QualForProducedTypeBean {
+
+  enum ProducerType {
+    FIELD, METHOD
+  }
+
+  boolean isStatic() default false;
+  ProducerType type() default ProducerType.METHOD;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/QualForTypedBean.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/QualForTypedBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.tests.wiring.client.res;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Retention(RUNTIME)
+@Target({ TYPE, FIELD, METHOD, PARAMETER })
+@Qualifier
+public @interface QualForTypedBean {
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedBaseType.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedBaseType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.tests.wiring.client.res;
 
 /**
- * @author Mike Brock
+ * 
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+public class TypedBaseType {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedProducer.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedProducer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.tests.wiring.client.res;
+
+import static org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType.FIELD;
+import static org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType.METHOD;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
+
+import org.jboss.errai.common.client.api.annotations.IOCProducer;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class TypedProducer {
+
+  @QualForProducedTypeBean(isStatic = true, type = METHOD)
+  @Typed({TypedType.class, TypedTargetInterface.class})
+  @IOCProducer
+  public static TypedType staticProducerMethod() {
+    return new TypedType();
+  }
+
+  @QualForProducedTypeBean(isStatic = true, type = FIELD)
+  @Typed({TypedType.class, TypedTargetInterface.class})
+  @IOCProducer
+  public static TypedType staticProducerField = new TypedType();
+
+  @QualForProducedTypeBean(isStatic = false, type = METHOD)
+  @Typed({TypedType.class, TypedTargetInterface.class})
+  @IOCProducer
+  public TypedType instanceProducerMethod() {
+    return new TypedType();
+  }
+
+  @QualForProducedTypeBean(isStatic = false, type = FIELD)
+  @Typed({TypedType.class, TypedTargetInterface.class})
+  @IOCProducer
+  public TypedType instanceProducerField = new TypedType();
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedSuperInterface.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedSuperInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.tests.wiring.client.res;
 
 /**
- * @author Mike Brock
+ * 
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+public interface TypedSuperInterface {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedTargetInterface.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedTargetInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.tests.wiring.client.res;
 
 /**
- * @author Mike Brock
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+public interface TypedTargetInterface extends TypedSuperInterface {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedType.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,18 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.tests.wiring.client.res;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
 
 /**
- * @author Mike Brock
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+@Typed({ TypedTargetInterface.class, TypedType.class })
+@Dependent
+@QualForTypedBean
+public class TypedType extends TypedBaseType implements TypedTargetInterface {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsBeanByWrongTypes.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForTypedBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsBeanByWrongTypes {
+
+  @Inject @QualForTypedBean TypedSuperInterface badSuperIface;
+  @Inject @QualForTypedBean TypedTargetInterface goodIface;
+  @Inject @QualForTypedBean TypedBaseType badSuperType;
+  @Inject @QualForTypedBean TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsInstanceFieldProducedBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsInstanceFieldProducedBeanByWrongTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsInstanceFieldProducedBeanByWrongTypes {
+
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.FIELD) TypedSuperInterface badSuperIface;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.FIELD) TypedTargetInterface goodIface;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.FIELD) TypedBaseType badSuperType;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.FIELD) TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsInstanceMethodProducedBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsInstanceMethodProducedBeanByWrongTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsInstanceMethodProducedBeanByWrongTypes {
+
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.METHOD) TypedSuperInterface badSuperIface;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.METHOD) TypedTargetInterface goodIface;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.METHOD) TypedBaseType badSuperType;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.METHOD) TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsStaticFieldProducedBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsStaticFieldProducedBeanByWrongTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsStaticFieldProducedBeanByWrongTypes {
+
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.FIELD) TypedSuperInterface badSuperIface;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.FIELD) TypedTargetInterface goodIface;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.FIELD) TypedBaseType badSuperType;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.FIELD) TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsStaticMethodProducedBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsStaticMethodProducedBeanByWrongTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsStaticMethodProducedBeanByWrongTypes {
+
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.METHOD) TypedSuperInterface badSuperIface;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.METHOD) TypedTargetInterface goodIface;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.METHOD) TypedBaseType badSuperType;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.METHOD) TypedType goodExactType;
+
+}


### PR DESCRIPTION
* Rework the mechanism for having injectables satisfy only injection
sites of the exact type of the injectable. Now each injectable supplies
a predicate that evaluates the path used to resolve itself for a given site.
The predicate can veto a path so that the injectable is not resolved
for that site.

* Use new path predicate mechanism to support @Typed. Beans with
@Typed have a predicate that only returns true if the injection
site is one of the types declared in the @Typed annotation.