### PR TITLE
ERRAI-1018: Support for javax.enterprise.inject.Typed

### DIFF
--- a/errai-codegen-gwt/src/main/java/org/jboss/errai/codegen/meta/impl/gwt/GWTClass.java
+++ b/errai-codegen-gwt/src/main/java/org/jboss/errai/codegen/meta/impl/gwt/GWTClass.java
@@ -96,29 +96,29 @@ public class GWTClass extends AbstractMetaClass<JType> {
     }
   }
 
-  
+
   public static class GWTClassCache implements CacheStore {
-    private final Map<String, MetaClass> reloadableClasses = new ConcurrentHashMap<String, MetaClass>();
+    private final Map<String, MetaClass> reloadableClasses = new ConcurrentHashMap<>();
 
     // Classes in .jar files can't change between refreshes so we can hold on to them
-    private final Map<String, MetaClass> classesInJar = new ConcurrentHashMap<String, MetaClass>();
+    private final Map<String, MetaClass> classesInJar = new ConcurrentHashMap<>();
 
     @Override
     public void clear() {
       reloadableClasses.clear();
     }
 
-    public void put(String name, MetaClass clazz) {
+    public void put(final String name, final MetaClass clazz) {
       if (AbstractScanner.isInJar(name) && !name.contains("<")) {
         classesInJar.put(name, clazz);
       }
-      else { 
+      else {
         reloadableClasses.put(name, clazz);
       }
     }
 
-    public MetaClass get(String name) {
-      final MetaClass clazz = classesInJar.get(name); 
+    public MetaClass get(final String name) {
+      final MetaClass clazz = classesInJar.get(name);
       if (clazz != null) {
         if (AbstractScanner.isInJar(name)) {
           return clazz;
@@ -129,20 +129,20 @@ public class GWTClass extends AbstractMetaClass<JType> {
         }
       }
       else {
-        return reloadableClasses.get(name);  
+        return reloadableClasses.get(name);
       }
     }
   }
-  
+
   final static GWTClassCache cache = CacheUtil.getCache(GWTClassCache.class);
-  
+
   public static MetaClass newInstance(final TypeOracle oracle, final JType type) {
     MetaClass clazz = cache.get(type.getParameterizedQualifiedSourceName());
     if (clazz == null) {
       clazz = newUncachedInstance(oracle, type);
       cache.put(type.getParameterizedQualifiedSourceName(), clazz);
     }
-    
+
     return clazz;
   }
 
@@ -205,9 +205,9 @@ public class GWTClass extends AbstractMetaClass<JType> {
     else {
       try {
         return Class.forName(name, false, Thread.currentThread().getContextClassLoader());
-      } 
+      }
       catch (final ClassNotFoundException e) {
-        throw new RuntimeException(e);      
+        throw new RuntimeException(e);
       }
     }
   }
@@ -222,7 +222,7 @@ public class GWTClass extends AbstractMetaClass<JType> {
     if (fqcn != null)  {
       return fqcn;
     }
-      
+
     if (isArray()) {
       if (getOuterComponentType().isPrimitive()) {
         fqcn = getInternalName();
@@ -253,7 +253,7 @@ public class GWTClass extends AbstractMetaClass<JType> {
     if (_packageName != null) {
       return _packageName;
     }
-    
+
     _packageName = getEnclosedMetaObject().isClassOrInterface().getPackage().getName();
     return _packageName;
   }
@@ -263,7 +263,7 @@ public class GWTClass extends AbstractMetaClass<JType> {
   }
 
   private List<MetaMethod> getSpecialTypeMethods() {
-    final List<MetaMethod> meths = new ArrayList<MetaMethod>();
+    final List<MetaMethod> meths = new ArrayList<>();
     final JEnumType type = getEnclosedMetaObject().isEnum();
 
     if (type != null) {
@@ -281,14 +281,14 @@ public class GWTClass extends AbstractMetaClass<JType> {
       Arrays.asList(MetaClassFactory.get(Object.class).getMethods());
 
   private MetaMethod[] _methodsCache = null;
-  
+
   @Override
   public MetaMethod[] getMethods() {
     if (_methodsCache != null) {
       return _methodsCache;
     }
-    
-    final Set<MetaMethod> meths = new LinkedHashSet<MetaMethod>();
+
+    final Set<MetaMethod> meths = new LinkedHashSet<>();
     meths.addAll(getSpecialTypeMethods());
 
     JClassType type = getEnclosedMetaObject().isClassOrInterface();
@@ -296,7 +296,7 @@ public class GWTClass extends AbstractMetaClass<JType> {
       return null;
     }
 
-    final Set<String> processedMethods = new HashSet<String>();
+    final Set<String> processedMethods = new HashSet<>();
     do {
       for (final JMethod jMethod : type.getMethods()) {
         final GWTMethod gwtMethod = new GWTMethod(oracle, jMethod);
@@ -320,7 +320,7 @@ public class GWTClass extends AbstractMetaClass<JType> {
     while ((type = type.getSuperclass()) != null && !type.getQualifiedSourceName().equals("java.lang.Object"));
     meths.addAll(overrideMethods);
     _methodsCache = meths.toArray(new MetaMethod[meths.size()]);
-    
+
     return _methodsCache;
   }
 
@@ -368,7 +368,7 @@ public class GWTClass extends AbstractMetaClass<JType> {
     if (type != null) {
       return Arrays.stream(type.getFields()).map(f -> new GWTField(oracle, f)).toArray(s -> new MetaField[s]);
     }
-    
+
     return new MetaField[0];
   }
 
@@ -449,17 +449,17 @@ public class GWTClass extends AbstractMetaClass<JType> {
   }
 
   private MetaClass[] _intefacesCache = null;
-  
+
   @Override
   public MetaClass[] getInterfaces() {
     if (_intefacesCache != null) {
       return _intefacesCache;
     }
-    
+
     final JClassType jClassType = getEnclosedMetaObject().isClassOrInterface();
     if (jClassType == null)
       return new MetaClass[0];
-    
+
     return _intefacesCache = Arrays.stream(jClassType.getImplementedInterfaces())
             .map(i -> new GWTClass(oracle, i, false)).toArray(s -> new MetaClass[s]);
   }
@@ -501,9 +501,18 @@ public class GWTClass extends AbstractMetaClass<JType> {
 
   @Override
   public MetaTypeVariable[] getTypeParameters() {
-    final JGenericType genericType = getEnclosedMetaObject().isGenericType();
+    final JGenericType genericType;
 
-    if (genericType == null) {
+    if (getEnclosedMetaObject().isGenericType() != null) {
+      genericType = getEnclosedMetaObject().isGenericType();
+    }
+    else if (getEnclosedMetaObject().isParameterized() != null) {
+      genericType = getEnclosedMetaObject().isParameterized().getBaseType();
+    }
+    else if (getEnclosedMetaObject().isRawType() != null) {
+      genericType = getEnclosedMetaObject().isRawType().getGenericType();
+    }
+    else {
       return new MetaTypeVariable[0];
     }
 

--- a/errai-codegen/src/main/java/org/jboss/errai/codegen/meta/impl/build/BuildMetaClass.java
+++ b/errai-codegen/src/main/java/org/jboss/errai/codegen/meta/impl/build/BuildMetaClass.java
@@ -55,7 +55,7 @@ public class BuildMetaClass extends AbstractMetaClass<Object> implements Builder
 
   private final String className;
   private MetaClass superClass;
-  private List<MetaClass> interfaces = new ArrayList<MetaClass>();
+  private List<MetaClass> interfaces = new ArrayList<>();
 
   private Scope scope;
 
@@ -70,13 +70,13 @@ public class BuildMetaClass extends AbstractMetaClass<Object> implements Builder
   private final BlockStatement staticInitializer = new BlockStatement();
   private final BlockStatement instanceInitializer = new BlockStatement();
 
-  private List<Annotation> annotations = new ArrayList<Annotation>();
-  private List<InnerClass> innerClasses = new ArrayList<InnerClass>();
+  private List<Annotation> annotations = new ArrayList<>();
+  private List<InnerClass> innerClasses = new ArrayList<>();
 
-  private List<BuildMetaMethod> methods = new ArrayList<BuildMetaMethod>();
-  private List<BuildMetaField> fields = new ArrayList<BuildMetaField>();
-  private List<BuildMetaConstructor> constructors = new ArrayList<BuildMetaConstructor>();
-  private List<MetaTypeVariable> typeVariables = new ArrayList<MetaTypeVariable>();
+  private List<BuildMetaMethod> methods = new ArrayList<>();
+  private List<BuildMetaField> fields = new ArrayList<>();
+  private List<BuildMetaConstructor> constructors = new ArrayList<>();
+  private List<MetaTypeVariable> typeVariables = new ArrayList<>();
   private MetaClass reifiedFormOf;
 
   private String classComment;
@@ -122,6 +122,10 @@ public class BuildMetaClass extends AbstractMetaClass<Object> implements Builder
   @Override
   public MetaClass getErased() {
     if (_erasedCache != null) {
+      return _erasedCache;
+    }
+    else if (typeVariables == null || typeVariables.isEmpty()) {
+      _erasedCache = this;
       return _erasedCache;
     }
     else {
@@ -190,7 +194,7 @@ public class BuildMetaClass extends AbstractMetaClass<Object> implements Builder
     final MetaMethod[] outputMethods;
 
     if (superClass != null) {
-      final List<MetaMethod> methodList = new ArrayList<MetaMethod>();
+      final List<MetaMethod> methodList = new ArrayList<>();
       for (final MetaMethod m : superClass.getMethods()) {
         if (_getMethod(methodArray, m.getName(), GenUtil.fromParameters(m.getParameters())) == null) {
           methodList.add(m);
@@ -607,7 +611,7 @@ public class BuildMetaClass extends AbstractMetaClass<Object> implements Builder
       buf.append(" class ").append(getName());
     }
 
-    final List<MetaClass> interfacesToRender = new ArrayList<MetaClass>(interfaces.size() + 1);
+    final List<MetaClass> interfacesToRender = new ArrayList<>(interfaces.size() + 1);
     interfacesToRender.addAll(interfaces);
 
     if (getSuperClass() != null) {
@@ -686,7 +690,7 @@ public class BuildMetaClass extends AbstractMetaClass<Object> implements Builder
   private List<Builder> diffList(final List<? extends Builder> original,
                                  final List<? extends Builder> against) {
 
-    final List<Builder> copyList = new ArrayList<Builder>(original);
+    final List<Builder> copyList = new ArrayList<>(original);
     copyList.removeAll(against);
     return copyList;
   }
@@ -734,8 +738,8 @@ public class BuildMetaClass extends AbstractMetaClass<Object> implements Builder
   }
 
   private StringBuilder renderFieldBuffer() {
-    List<Builder> toBuild = new ArrayList<Builder>(fields);
-    final List<Builder> toIterate = new ArrayList<Builder>(toBuild);
+    List<Builder> toBuild = new ArrayList<>(fields);
+    final List<Builder> toIterate = new ArrayList<>(toBuild);
 
     int initialFieldSize;
 
@@ -766,7 +770,7 @@ public class BuildMetaClass extends AbstractMetaClass<Object> implements Builder
       }
 
       toIterate.addAll(0, diffList(fields, toBuild));
-      toBuild = new ArrayList<Builder>(fields);
+      toBuild = new ArrayList<>(fields);
     }
     while (initialFieldSize < fields.size());
 

--- a/errai-codegen/src/main/java/org/jboss/errai/codegen/meta/impl/java/JavaReflectionClass.java
+++ b/errai-codegen/src/main/java/org/jboss/errai/codegen/meta/impl/java/JavaReflectionClass.java
@@ -108,7 +108,7 @@ public class JavaReflectionClass extends AbstractMetaClass<Class> {
 
   @Override
   public MetaClass getErased() {
-    if (getEnclosedMetaObject().getTypeParameters().length == 0) {
+    if (parameterizedType == null) {
       return this;
     }
     return new JavaReflectionClass(getEnclosedMetaObject(), true);
@@ -144,7 +144,7 @@ public class JavaReflectionClass extends AbstractMetaClass<Class> {
   }
 
   private MetaMethod[] fromMethodArray(final Method[] methods) {
-    final List<MetaMethod> methodList = new ArrayList<MetaMethod>();
+    final List<MetaMethod> methodList = new ArrayList<>();
 
     for (final Method m : methods) {
       // hack to exclude jacoco instrumented methods.
@@ -164,14 +164,14 @@ public class JavaReflectionClass extends AbstractMetaClass<Class> {
       return _methodCache;
     }
 
-    final Set<MetaMethod> meths = new LinkedHashSet<MetaMethod>();
+    final Set<MetaMethod> meths = new LinkedHashSet<>();
 
     Class<?> type = getEnclosedMetaObject();
     if (type == null) {
       return null;
     }
 
-    final Set<String> processedMethods = new HashSet<String>();
+    final Set<String> processedMethods = new HashSet<>();
     do {
       for (final Method method : type.getDeclaredMethods()) {
         final JavaReflectionMethod metaMethod = new JavaReflectionMethod(this, method);
@@ -332,7 +332,7 @@ public class JavaReflectionClass extends AbstractMetaClass<Class> {
       return _interfacesCache;
     }
 
-    final List<MetaClass> metaClassList = new ArrayList<MetaClass>();
+    final List<MetaClass> metaClassList = new ArrayList<>();
     final Type[] genIface = getEnclosedMetaObject().getGenericInterfaces();
 
     int i = 0;
@@ -455,7 +455,7 @@ public class JavaReflectionClass extends AbstractMetaClass<Class> {
     return getEnclosedMetaObject().isAnonymousClass();
   }
 
-  private final Map<Integer, MetaClass> _arrayTypeCache = new HashMap<Integer, MetaClass>();
+  private final Map<Integer, MetaClass> _arrayTypeCache = new HashMap<>();
 
   @Override
   public MetaClass asArrayOf(final int dimensions) {

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/client/api/builtin/ManagedInstanceProvider.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/client/api/builtin/ManagedInstanceProvider.java
@@ -181,7 +181,7 @@ public class ManagedInstanceProvider implements ContextualTypeProvider<ManagedIn
 
     @Override
     public Iterator<T> iterator() {
-      return new ManagedInstanceImplIterator<S, T>(getBeanManager().lookupBeans(key.type, qualifierArray()), key, dependentInstances);
+      return new ManagedInstanceImplIterator<>(getBeanManager().lookupBeans(key.type, qualifierArray()), key, dependentInstances);
     }
 
     @Override

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/DependencyGraphBuilder.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/DependencyGraphBuilder.java
@@ -17,6 +17,8 @@
 package org.jboss.errai.ioc.rebind.ioc.graph.api;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.function.Predicate;
 
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -31,6 +33,7 @@ import org.jboss.errai.codegen.meta.MetaParameter;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.rebind.ioc.extension.IOCExtensionConfigurator;
 import org.jboss.errai.ioc.rebind.ioc.extension.builtin.LoggerFactoryIOCExtension;
+import org.jboss.errai.ioc.rebind.ioc.graph.impl.InjectableHandle;
 import org.jboss.errai.ioc.rebind.ioc.graph.impl.ResolutionPriority;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.InjectableProvider;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.WiringElementType;
@@ -64,17 +67,21 @@ public interface DependencyGraphBuilder {
    *          The class of the injectable.
    * @param qualifier
    *          The {@link Qualifier} of the injectable.
+   * @param pathPredicate
+   *          Used to add restrictions on what dependencies are satisfied by the added injectable. This predicate is
+   *          called anytime the created injectable is a candidate for a dependency. The predicate argument is the
+   *          {@link InjectableHandle InjectableHandles} traversed in order to arrive at this injectable. If the
+   *          predicate returns false, the injectable does not satisfy a dependency.
    * @param literalScope
    *          The {@link Scope} of the injectable.
    * @param injectableType
    *          The kind of injectable (i.e. producer, provider, type, etc.).
    * @param wiringTypes
-   *          A collection of {@link WiringElementType wiring types} that this
-   *          injectable has.
+   *          A collection of {@link WiringElementType wiring types} that this injectable has.
    *
    * @return The newly added {@link Injectable}.
    */
-  Injectable addInjectable(MetaClass injectedType, Qualifier qualifier, Class<? extends Annotation> literalScope,
+  Injectable addInjectable(MetaClass injectedType, Qualifier qualifier, Predicate<List<InjectableHandle>> pathPredicate, Class<? extends Annotation> literalScope,
           InjectableType injectableType, WiringElementType... wiringTypes);
 
   /**
@@ -90,6 +97,11 @@ public interface DependencyGraphBuilder {
    *          The class of the injectable.
    * @param qualifier
    *          The {@link Qualifier} of the injectable.
+   * @param pathPredicate
+   *          Used to add restrictions on what dependencies are satisfied by the added injectable. This predicate is
+   *          called anytime the created injectable is a candidate for a dependency. The predicate argument is the
+   *          {@link InjectableHandle InjectableHandles} traversed in order to arrive at this injectable. If the
+   *          predicate returns false, the injectable does not satisfy a dependency.
    * @param literalScope
    *          The {@link Scope} of the injectable.
    * @param injectableType
@@ -100,7 +112,9 @@ public interface DependencyGraphBuilder {
    *
    * @return The newly added extension {@link Injectable}.
    */
-  Injectable addExtensionInjectable(MetaClass injectedType, Qualifier qualifier, InjectableProvider provider, WiringElementType... wiringTypes);
+  Injectable addExtensionInjectable(MetaClass injectedType, Qualifier qualifier,
+          Predicate<List<InjectableHandle>> pathPredicate, InjectableProvider provider,
+          WiringElementType... wiringTypes);
 
   /**
    * Create a dependency for a field injection point in a bean class.

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/DependencyGraphBuilder.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/DependencyGraphBuilder.java
@@ -231,7 +231,7 @@ public interface DependencyGraphBuilder {
    * @author Max Barkley <mbarkley@redhat.com>
    */
   public static enum InjectableType {
-    Type, JsType, Producer, Provider, ContextualProvider, Reference, Extension, ExtensionProvided, Static, Disabled
+    Type, JsType, Producer, Provider, ContextualProvider, Extension, ExtensionProvided, Static, Disabled
   }
 
   /**

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/Injectable.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/api/Injectable.java
@@ -18,10 +18,12 @@ package org.jboss.errai.ioc.rebind.ioc.graph.api;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Named;
 
+import org.jboss.errai.codegen.meta.HasAnnotations;
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.ioc.client.api.ContextualTypeProvider;
 import org.jboss.errai.ioc.client.api.LoadAsync;
@@ -43,6 +45,11 @@ public interface Injectable extends HasInjectableHandle {
    *         should return {@link Dependent}.
    */
   Class<? extends Annotation> getScope();
+
+  /**
+   * @return If available, the annotated object that is the source of this injectable.
+   */
+  Optional<HasAnnotations> getAnnotatedObject();
 
   /**
    * @return The name of this injectable if {@link Named} annotation was

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DefaultCustomFactoryInjectable.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DefaultCustomFactoryInjectable.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.ioc.rebind.ioc.bootstrapper.FactoryBodyGenerator;
+import org.jboss.errai.ioc.rebind.ioc.bootstrapper.IOCProcessor;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.CustomFactoryInjectable;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.InjectableType;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Qualifier;
@@ -36,7 +37,7 @@ public class DefaultCustomFactoryInjectable extends InjectableImpl implements Cu
   public DefaultCustomFactoryInjectable(final MetaClass type, final Qualifier qualifier, final String factoryName,
           final Class<? extends Annotation> literalScope, final Collection<WiringElementType> wiringTypes,
           final FactoryBodyGenerator generator) {
-    super(type, qualifier, factoryName, literalScope, InjectableType.ExtensionProvided, wiringTypes);
+    super(type, qualifier, IOCProcessor.ANY, factoryName, literalScope, InjectableType.ExtensionProvided, wiringTypes);
     this.generator = generator;
   }
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DefaultQualifierFactory.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DefaultQualifierFactory.java
@@ -284,7 +284,7 @@ public class DefaultQualifierFactory implements QualifierFactory {
 
     @Override
     public String toString() {
-      return annotations.toString();
+      return annotations.stream().map(AnnotationWrapper::toString).reduce((s1, s2) -> s1 + " " + s2).orElse("");
     }
 
     @Override
@@ -343,7 +343,7 @@ public class DefaultQualifierFactory implements QualifierFactory {
 
     @Override
     public String toString() {
-      return getIdentifierSafeString();
+      return "@" + getIdentifierSafeString();
     }
 
     @Override

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DependencyGraphBuilderImpl.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/DependencyGraphBuilderImpl.java
@@ -44,6 +44,7 @@ import org.jboss.errai.codegen.meta.MetaField;
 import org.jboss.errai.codegen.meta.MetaMethod;
 import org.jboss.errai.codegen.meta.MetaParameter;
 import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.ioc.rebind.ioc.bootstrapper.IOCProcessor;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraph;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Injectable;
@@ -69,7 +70,6 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
   private final QualifierFactory qualFactory;
   private final Map<InjectableHandle, InjectableReference> injectableReferences = new HashMap<>();
   private final Multimap<MetaClass, InjectableReference> directInjectableReferencesByAssignableTypes = HashMultimap.create();
-  private final Multimap<MetaClass, InjectableImpl> exactTypeInjectablesByType = HashMultimap.create();
   private final Map<String, Injectable> injectablesByName = new HashMap<>();
   private final List<InjectableImpl> specializations = new ArrayList<>();
   private final FactoryNameGenerator nameGenerator = new FactoryNameGenerator();
@@ -81,9 +81,10 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
   }
 
   @Override
-  public Injectable addInjectable(final MetaClass injectedType, final Qualifier qualifier, final Class<? extends Annotation> literalScope,
+  public Injectable addInjectable(final MetaClass injectedType, final Qualifier qualifier,
+          final Predicate<List<InjectableHandle>> pathPredicate, final Class<? extends Annotation> literalScope,
           final InjectableType injectableType, final WiringElementType... wiringTypes) {
-    final InjectableImpl injectable = new InjectableImpl(injectedType, qualifier,
+    final InjectableImpl injectable = new InjectableImpl(injectedType, qualifier, pathPredicate,
             nameGenerator.generateFor(injectedType, qualifier, injectableType), literalScope, injectableType,
             Arrays.asList(wiringTypes));
 
@@ -100,11 +101,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     if (injectable.wiringTypes.contains(WiringElementType.Specialization)) {
       specializations.add(injectable);
     }
-    if (injectable.wiringTypes.contains(WiringElementType.ExactTypeMatching)) {
-      exactTypeInjectablesByType.put(injectable.type.getErased(), injectable);
-    } else {
-      linkDirectInjectableReference(injectable);
-    }
+    linkDirectInjectableReference(injectable);
 
     return injectable;
   }
@@ -119,8 +116,9 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   @Override
   public Injectable addExtensionInjectable(final MetaClass injectedType, final Qualifier qualifier,
-          final InjectableProvider provider, final WiringElementType... wiringTypes) {
-    final InjectableImpl injectable = new ExtensionInjectable(injectedType, qualifier,
+          final Predicate<List<InjectableHandle>> pathPredicate, final InjectableProvider provider,
+          final WiringElementType... wiringTypes) {
+    final InjectableImpl injectable = new ExtensionInjectable(injectedType, qualifier, pathPredicate,
             nameGenerator.generateFor(injectedType, qualifier, InjectableType.Extension), null,
             InjectableType.Extension, Arrays.asList(wiringTypes), provider);
     return registerNewInjectable(injectable);
@@ -180,7 +178,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
   }
 
   private Collection<Validator> createValidators() {
-    final Collection<Validator> validators = new ArrayList<Validator>();
+    final Collection<Validator> validators = new ArrayList<>();
     validators.add(new CycleValidator());
     if (async) {
       validators.add(new AsyncValidator());
@@ -227,7 +225,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     /*
      * Need to copy this because the call to lookupInjectableReference may modify the collection.
      */
-    final Collection<InjectableReference> directInjectableReferencesOfProducedType = new ArrayList<InjectableReference>(
+    final Collection<InjectableReference> directInjectableReferencesOfProducedType = new ArrayList<>(
             directInjectableReferencesByAssignableTypes.get(producedType));
     for (final InjectableReference injectable : directInjectableReferencesOfProducedType) {
       if (injectable.type.equals(producedType)) {
@@ -285,7 +283,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
   }
 
   private void removeLinksToProducedTypes(final InjectableImpl specialized, final Set<InjectableImpl> toBeRemoved) {
-    final Collection<InjectableReference> producedReferences = new ArrayList<InjectableReference>();
+    final Collection<InjectableReference> producedReferences = new ArrayList<>();
     for (final MetaMethod method : specialized.type.getDeclaredMethodsAnnotatedWith(Produces.class)) {
       producedReferences.add(lookupInjectableReference(method.getReturnType(), qualFactory.forSource(method)));
     }
@@ -313,7 +311,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   private void validateInjectables() {
     logger.debug("Validating dependency graph...");
-    final Collection<String> problems = new ArrayList<String>();
+    final Collection<String> problems = new ArrayList<>();
     final Collection<Validator> validators = createValidators();
     for (final Injectable injectable : injectablesByName.values()) {
       for (final Validator validator : validators) {
@@ -329,8 +327,8 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   private void removeUnreachableInjectables(final ReachabilityStrategy strategy) {
     logger.debug("Removing unreachable injectables from dependency graph using {} strategy.", strategy);
-    final Set<String> reachableNames = new HashSet<String>();
-    final Queue<Injectable> processingQueue = new LinkedList<Injectable>();
+    final Set<String> reachableNames = new HashSet<>();
+    final Queue<Injectable> processingQueue = new LinkedList<>();
     final Predicate<Injectable> reachabilityRoot = reachabilityRootPredicate(strategy);
     for (final Injectable injectable : injectablesByName.values()) {
       if (reachabilityRoot.test(injectable)
@@ -371,10 +369,10 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   private void resolveDependencies() {
     logger.debug("Resolving dependencies for {} injectables...", injectablesByName.size());
-    final Set<Injectable> visited = new HashSet<Injectable>();
-    final Set<String> transientInjectableNames = new HashSet<String>();
-    final List<String> dependencyProblems = new ArrayList<String>();
-    final Map<String, Injectable> customProvidedInjectables = new IdentityHashMap<String, Injectable>();
+    final Set<Injectable> visited = new HashSet<>();
+    final Set<String> transientInjectableNames = new HashSet<>();
+    final List<String> dependencyProblems = new ArrayList<>();
+    final Map<String, Injectable> customProvidedInjectables = new IdentityHashMap<>();
 
     for (final Injectable injectable : injectablesByName.values()) {
       if (injectable.isExtension()) {
@@ -404,12 +402,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     }
 
     logger.trace("Resolving dependency: {}", dep);
-    final Multimap<ResolutionPriority, InjectableImpl> resolvedByPriority = HashMultimap.create();
-    final Queue<InjectableReference> resolutionQueue = new LinkedList<InjectableReference>();
-    resolutionQueue.add(dep.injectable);
-    resolutionQueue.add(addMatchingExactTypeInjectables(dep.injectable));
-
-    processResolutionQueue(resolutionQueue, resolvedByPriority);
+    final Multimap<ResolutionPriority, InjectableImpl> resolvedByPriority = traverseLinks(dep.injectable);
 
     final Iterable<ResolutionPriority> priorities;
     final boolean reportProblems;
@@ -428,7 +421,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
         final Collection<InjectableImpl> resolved = resolvedByPriority.get(priority);
         if (resolved.size() > 1) {
           if (reportProblems) {
-            problems.add(GraphUtil.ambiguousDependencyMessage(dep, depOwner, new ArrayList<InjectableImpl>(resolved)));
+            problems.add(GraphUtil.ambiguousDependencyMessage(dep, depOwner, new ArrayList<>(resolved)));
           }
 
           return null;
@@ -461,7 +454,7 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     Injectable injectable = resolved.iterator().next();
     if (injectable.isExtension()) {
       final ExtensionInjectable providedInjectable = (ExtensionInjectable) injectable;
-      final Collection<Injectable> otherResolvedInjectables = new ArrayList<Injectable>(resolvedByPriority.values());
+      final Collection<Injectable> otherResolvedInjectables = new ArrayList<>(resolvedByPriority.values());
       otherResolvedInjectables.remove(injectable);
 
       final InjectionSite site = new InjectionSite(depOwner.getInjectedType(), dep, otherResolvedInjectables);
@@ -473,34 +466,78 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
     return injectable;
   }
 
-  private InjectableReference addMatchingExactTypeInjectables(final InjectableReference depInjectable) {
-    final InjectableReference exactTypeLinker = new InjectableReference(depInjectable.type, depInjectable.qualifier);
-    for (final InjectableImpl candidate : exactTypeInjectablesByType.get(depInjectable.type.getErased())) {
-      if (GraphUtil.candidateSatisfiesInjectable(depInjectable, candidate, !candidate.isContextual())) {
-        exactTypeLinker.linked.add(candidate);
-      }
-    }
-
-    return exactTypeLinker;
-  }
-
-  private void processResolutionQueue(final Queue<InjectableReference> resolutionQueue,
-          final Multimap<ResolutionPriority, InjectableImpl> resolvedByPriority) {
-    logger.trace("Processing resolution queue with {} initial references...", resolutionQueue.size());
+  private Multimap<ResolutionPriority, InjectableImpl> traverseLinks(final InjectableReference dep) {
+    final Multimap<ResolutionPriority, InjectableImpl> resolvedByPriority = HashMultimap.create();
+    final LinkedList<InjectableHandle> handleStack = new LinkedList<>();
+    final LinkedList<Iterator<InjectableBase>> linkStack = new LinkedList<>();
+    handleStack.addLast(dep.getHandle());
+    linkStack.addLast(dep.linked.iterator());
     do {
-      final InjectableReference cur = resolutionQueue.poll();
-      logger.trace("Processing links of reference: {}", cur);
-      for (final InjectableBase link : cur.linked) {
+      final Iterator<InjectableBase> iter = linkStack.getLast();
+      if (iter.hasNext()) {
+        final InjectableBase link = iter.next();
         if (link instanceof InjectableReference) {
-          logger.trace("Adding linked reference to resolution queue: {}", link);
-          resolutionQueue.add((InjectableReference) link);
+          logger.trace("Adding linked reference to resolution stack: {}", link);
+          handleStack.addLast(link.getHandle());
+          if (isRawType(link.type)) {
+            /*
+             * SPECIAL CASE:
+             * Java types with the relation "assignableTo" would form an ordering of types,
+             * EXCEPT that raw types are assignable to any parameterization and vice-versa.
+             *
+             * This breaks anti-symmetry (A<B> assignableTo A and A assignableTo A<B> but A != A<B>)
+             * and transitivity (for unrelated B and C, A<B> assignableTo A assignableTo A<C> but NOT
+             * A<B> assignableTo A<C> since NOT B assignableTo C).
+             *
+             * As a consequence, following reference links from a raw type can lead to cycles (from lack of anti-symmetry)
+             * or incorrect resolution of parameterized types (from lack of transitivity).
+             *
+             * The only time following reference links from a raw type is acceptable is when they
+             * are at the beginning of a path being traversed (since then we really do want to find any possible
+             * parameterization, and when we arrive back at the same raw-typed reference we will ignore the reference
+             * links that we have already traversed, which avoids the possibility of an endless cycle).
+             */
+            linkStack.addLast(getIteratorOfRawTypedInjectableLinks(link));
+          }
+          else {
+            linkStack.addLast(((InjectableReference) link).linked.iterator());
+          }
         } else if (link instanceof InjectableImpl) {
-          logger.trace("Adding linked injectable to resolution results: {}", link);
-          resolvedByPriority.put(getMatchingPriority((InjectableImpl) link), (InjectableImpl) link);
+          final InjectableImpl resolvedInjectable = (InjectableImpl) link;
+          if (resolvedInjectable.pathPredicate.test(handleStack)) {
+            logger.trace("Adding linked injectable to resolution results: {}", link);
+            resolvedByPriority.put(getMatchingPriority(resolvedInjectable), resolvedInjectable);
+          }
+          else {
+            logger.trace("Rejecting linked injectable from resolution results based on path predicate: {}", link);
+          }
         }
       }
-    } while (resolutionQueue.size() > 0);
-    logger.trace("Finished processing resolution queue. Resolved {} injectables.", resolvedByPriority.size());
+      else {
+        handleStack.removeLast();
+        linkStack.removeLast();
+      }
+    } while (!linkStack.isEmpty());
+    logger.trace("Finished processing resolution stack. Resolved {} injectables.", resolvedByPriority.size());
+
+    return resolvedByPriority;
+  }
+
+  private Iterator<InjectableBase> getIteratorOfRawTypedInjectableLinks(final InjectableBase link) {
+    final List<InjectableBase> injectableLinks =
+            ((InjectableReference) link)
+            .linked
+            .stream()
+            .filter(l -> l instanceof InjectableImpl)
+            .filter(l -> isRawType(l.type))
+            .collect(Collectors.toList());
+    final Iterator<InjectableBase> injectablesInterator = injectableLinks.iterator();
+    return injectablesInterator;
+  }
+
+  private boolean isRawType(final MetaClass type) {
+    // Guaranteed to be true for all raw types in all MetaClass impls
+    return type == type.getErased();
   }
 
   private Injectable getRootDisabledInjectable(Injectable inj, final Collection<String> problems,
@@ -544,8 +581,8 @@ public final class DependencyGraphBuilderImpl implements DependencyGraphBuilder 
 
   private InjectableReference createStaticMemberInjectable(final MetaClass producerType, final MetaClassMember member) {
     final InjectableReference retVal = new InjectableReference(producerType, qualFactory.forUniversallyQualified());
-    retVal.resolution = new InjectableImpl(producerType, qualFactory.forUniversallyQualified(), "",
-            ApplicationScoped.class, InjectableType.Static, Collections.<WiringElementType>emptyList());
+    retVal.resolution = new InjectableImpl(producerType, qualFactory.forUniversallyQualified(), IOCProcessor.ANY, "",
+            ApplicationScoped.class, InjectableType.Static, Collections.<WiringElementType> emptyList());
 
     return retVal;
   }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/ExtensionInjectable.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/ExtensionInjectable.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder;
@@ -35,13 +37,13 @@ import org.jboss.errai.ioc.rebind.ioc.injector.api.WiringElementType;
  */
 class ExtensionInjectable extends InjectableImpl {
 
-  final Collection<InjectionSite> injectionSites = new ArrayList<InjectionSite>();
+  final Collection<InjectionSite> injectionSites = new ArrayList<>();
   final InjectableProvider provider;
 
-  ExtensionInjectable(final MetaClass type, final Qualifier qualifier, final String factoryName,
-          final Class<? extends Annotation> literalScope, final InjectableType injectorType,
+  ExtensionInjectable(final MetaClass type, final Qualifier qualifier, final Predicate<List<InjectableHandle>> pathPredicate,
+          final String factoryName, final Class<? extends Annotation> literalScope, final InjectableType injectorType,
           final Collection<WiringElementType> wiringTypes, final InjectableProvider provider) {
-    super(type, qualifier, factoryName, literalScope, injectorType, wiringTypes);
+    super(type, qualifier, pathPredicate, factoryName, literalScope, injectorType, wiringTypes);
     this.provider = provider;
   }
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/GraphUtil.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/GraphUtil.java
@@ -20,10 +20,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.lang3.Validate;
 import org.jboss.errai.codegen.meta.MetaClass;
-import org.jboss.errai.codegen.meta.MetaClassFactory;
 import org.jboss.errai.codegen.meta.MetaMethod;
 import org.jboss.errai.codegen.meta.MetaParameterizedType;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.Dependency;
@@ -207,12 +207,12 @@ final class GraphUtil {
 
   static boolean hasAssignableTypeParameters(final MetaClass fromType, final MetaClass toType) {
     final MetaParameterizedType toParamType = toType.getParameterizedType();
-    final MetaParameterizedType fromParamType = GraphUtil.getFromTypeParams(fromType, toType);
+    final Optional<MetaParameterizedType> fromParamType = GraphUtil.getFromTypeParams(fromType, toType);
 
-    return toParamType == null || toParamType.isAssignableFrom(fromParamType);
+    return toParamType == null || fromParamType.map(type -> toParamType.isAssignableFrom(type)).orElse(true);
   }
 
-  static MetaParameterizedType getFromTypeParams(final MetaClass fromType, final MetaClass toType) {
+  static Optional<MetaParameterizedType> getFromTypeParams(final MetaClass fromType, final MetaClass toType) {
     MetaClass parameterContainingType = null;
     if (toType.isInterface()) {
       if (fromType.getFullyQualifiedName().equals(toType.getFullyQualifiedName())) {
@@ -241,10 +241,10 @@ final class GraphUtil {
       + " through type " + fromType.getFullyQualifiedName());
     }
     else if (parameterContainingType.getParameterizedType() != null) {
-      return parameterContainingType.getParameterizedType();
+      return Optional.of(parameterContainingType.getParameterizedType());
     }
     else {
-      return MetaClassFactory.typeParametersOf(parameterContainingType.getTypeParameters());
+      return Optional.empty();
     }
   }
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableBase.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableBase.java
@@ -18,7 +18,6 @@ package org.jboss.errai.ioc.rebind.ioc.graph.impl;
 
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Qualifier;
-import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.InjectableType;
 
 /**
  * Common base class for {@link InjectableImpl} and
@@ -44,14 +43,6 @@ abstract class InjectableBase {
   public MetaClass getInjectedType() {
     return type;
   }
-
-  @Override
-  public String toString() {
-    return "[class=" + getInjectedType() + ", injectorType=" + getInjectableType() + ", qualifier="
-            + getQualifier().toString() + "]";
-  }
-
-  public abstract InjectableType getInjectableType();
 
   public Qualifier getQualifier() {
     return qualifier;

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableHandle.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableHandle.java
@@ -51,7 +51,7 @@ public class InjectableHandle {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(final Object obj) {
     if (!(obj instanceof InjectableHandle))
       return false;
 
@@ -66,6 +66,6 @@ public class InjectableHandle {
 
   @Override
   public String toString() {
-    return "[AbstractInjectableHandle:" + type.getName() + "$" + qualifier.toString() + "]";
+    return String.format("%s %s", getQualifier(), getType().getFullyQualifiedNameWithTypeParms());
   }
 }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableImpl.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableImpl.java
@@ -93,7 +93,6 @@ class InjectableImpl extends InjectableBase implements Injectable {
   @Override
   public boolean requiresProxy() {
     switch (injectableType) {
-    case Reference:
     case ContextualProvider:
     case Provider:
       return false;
@@ -144,5 +143,44 @@ class InjectableImpl extends InjectableBase implements Injectable {
     }
 
     return hashContent;
+  }
+
+  @Override
+  public String toString() {
+    final String injectableDescriptor;
+    switch (injectableType) {
+    case ContextualProvider:
+      injectableDescriptor = "ContextualProvider";
+      break;
+    case Disabled:
+      injectableDescriptor = "Disabled";
+      break;
+    case Extension:
+      injectableDescriptor = "Extension";
+      break;
+    case ExtensionProvided:
+      injectableDescriptor = "ExtensionProvided";
+      break;
+    case JsType:
+      injectableDescriptor = "@JsType";
+      break;
+    case Producer:
+      injectableDescriptor = "@Produces";
+      break;
+    case Provider:
+      injectableDescriptor = "Provider";
+      break;
+    case Static:
+      injectableDescriptor = "@Produces";
+      break;
+    case Type:
+      injectableDescriptor = "Class";
+      break;
+    default:
+      injectableDescriptor = "";
+      break;
+    }
+
+    return String.format("%s %s %s", injectableDescriptor, getQualifier(), getInjectedType().getFullyQualifiedNameWithTypeParms());
   }
 }

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableImpl.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableImpl.java
@@ -21,10 +21,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 
+import org.jboss.errai.codegen.meta.HasAnnotations;
 import org.jboss.errai.codegen.meta.MetaClass;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.Dependency;
+import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.DependencyType;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.InjectableType;
+import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.ProducerInstanceDependency;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Injectable;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Qualifier;
 import org.jboss.errai.ioc.rebind.ioc.injector.api.WiringElementType;
@@ -45,20 +50,23 @@ import org.jboss.errai.ioc.rebind.ioc.injector.api.WiringElementType;
 class InjectableImpl extends InjectableBase implements Injectable {
   final InjectableType injectableType;
   final Collection<WiringElementType> wiringTypes;
-  final List<BaseDependency> dependencies = new ArrayList<BaseDependency>();
+  final List<BaseDependency> dependencies = new ArrayList<>();
   final Class<? extends Annotation> literalScope;
   Boolean proxiable = null;
   boolean requiresProxy = false;
   Integer hashContent = null;
   final String factoryName;
+  final Predicate<List<InjectableHandle>> pathPredicate;
 
   InjectableImpl(final MetaClass type,
                      final Qualifier qualifier,
+                     final Predicate<List<InjectableHandle>> pathPredicate,
                      final String factoryName,
                      final Class<? extends Annotation> literalScope,
                      final InjectableType injectorType,
                      final Collection<WiringElementType> wiringTypes) {
     super(type, qualifier);
+    this.pathPredicate = pathPredicate;
     this.factoryName = factoryName;
     this.literalScope = literalScope;
     this.wiringTypes = wiringTypes;
@@ -104,6 +112,29 @@ class InjectableImpl extends InjectableBase implements Injectable {
     case Extension:
     default:
       throw new RuntimeException("Not yet implemented!");
+    }
+  }
+
+  @Override
+  public Optional<HasAnnotations> getAnnotatedObject() {
+    switch (injectableType) {
+    case Type:
+      return Optional.of(type);
+    case Producer:
+    case Static:
+    case Provider:
+    case ContextualProvider:
+      return dependencies
+              .stream()
+              .filter(dep -> DependencyType.ProducerMember.equals(dep.dependencyType))
+              .map(dep -> (HasAnnotations) ((ProducerInstanceDependency) dep).getProducingMember())
+              .findFirst();
+    case ExtensionProvided:
+    case Extension:
+    case JsType:
+    case Disabled:
+    default:
+      return Optional.empty();
     }
   }
 

--- a/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableReference.java
+++ b/errai-ioc/src/main/java/org/jboss/errai/ioc/rebind/ioc/graph/impl/InjectableReference.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import org.jboss.errai.codegen.meta.MetaClass;
-import org.jboss.errai.ioc.rebind.ioc.graph.api.DependencyGraphBuilder.InjectableType;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.HasInjectableHandle;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Injectable;
 import org.jboss.errai.ioc.rebind.ioc.graph.api.Qualifier;
@@ -34,7 +33,7 @@ import org.jboss.errai.ioc.rebind.ioc.graph.api.Qualifier;
 class InjectableReference extends InjectableBase implements HasInjectableHandle {
   // TODO needs to be renamed and not be an Injectable
 
-  final Collection<InjectableBase> linked = new HashSet<InjectableBase>();
+  final Collection<InjectableBase> linked = new HashSet<>();
   Injectable resolution;
 
   InjectableReference(final MetaClass type, final Qualifier qualifier) {
@@ -42,8 +41,8 @@ class InjectableReference extends InjectableBase implements HasInjectableHandle 
   }
 
   @Override
-  public InjectableType getInjectableType() {
-    return InjectableType.Reference;
+  public String toString() {
+    return String.format("%s %s", getQualifier(), getInjectedType().getFullyQualifiedNameWithTypeParms());
   }
 
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/QualForProducedTypeBean.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/QualForProducedTypeBean.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.tests.wiring.client.res;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Retention(RUNTIME)
+@Target({ TYPE, FIELD, METHOD, PARAMETER })
+@Qualifier
+public @interface QualForProducedTypeBean {
+
+  enum ProducerType {
+    FIELD, METHOD
+  }
+
+  boolean isStatic() default false;
+  ProducerType type() default ProducerType.METHOD;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/QualForTypedBean.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/QualForTypedBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.tests.wiring.client.res;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Retention(RUNTIME)
+@Target({ TYPE, FIELD, METHOD, PARAMETER })
+@Qualifier
+public @interface QualForTypedBean {
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedBaseType.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedBaseType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.tests.wiring.client.res;
 
 /**
- * @author Mike Brock
+ * 
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+public class TypedBaseType {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedProducer.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedProducer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.tests.wiring.client.res;
+
+import static org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType.FIELD;
+import static org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType.METHOD;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
+
+import org.jboss.errai.common.client.api.annotations.IOCProducer;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class TypedProducer {
+
+  @QualForProducedTypeBean(isStatic = true, type = METHOD)
+  @Typed({TypedType.class, TypedTargetInterface.class})
+  @IOCProducer
+  public static TypedType staticProducerMethod() {
+    return new TypedType();
+  }
+
+  @QualForProducedTypeBean(isStatic = true, type = FIELD)
+  @Typed({TypedType.class, TypedTargetInterface.class})
+  @IOCProducer
+  public static TypedType staticProducerField = new TypedType();
+
+  @QualForProducedTypeBean(isStatic = false, type = METHOD)
+  @Typed({TypedType.class, TypedTargetInterface.class})
+  @IOCProducer
+  public TypedType instanceProducerMethod() {
+    return new TypedType();
+  }
+
+  @QualForProducedTypeBean(isStatic = false, type = FIELD)
+  @Typed({TypedType.class, TypedTargetInterface.class})
+  @IOCProducer
+  public TypedType instanceProducerField = new TypedType();
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedSuperInterface.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedSuperInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.tests.wiring.client.res;
 
 /**
- * @author Mike Brock
+ * 
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+public interface TypedSuperInterface {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedTargetInterface.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedTargetInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.tests.wiring.client.res;
 
 /**
- * @author Mike Brock
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+public interface TypedTargetInterface extends TypedSuperInterface {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedType.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/tests/wiring/client/res/TypedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,18 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.tests.wiring.client.res;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
 
 /**
- * @author Mike Brock
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+@Typed({ TypedTargetInterface.class, TypedType.class })
+@Dependent
+@QualForTypedBean
+public class TypedType extends TypedBaseType implements TypedTargetInterface {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/ClassWithBadTypedAnnotation.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/ClassWithBadTypedAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,19 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.unit.res;
+
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
 
 /**
- * @author Mike Brock
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+@Dependent
+@Typed(List.class)
+public class ClassWithBadTypedAnnotation {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsBeanByWrongTypes.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForTypedBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsBeanByWrongTypes {
+
+  @Inject @QualForTypedBean TypedSuperInterface badSuperIface;
+  @Inject @QualForTypedBean TypedTargetInterface goodIface;
+  @Inject @QualForTypedBean TypedBaseType badSuperType;
+  @Inject @QualForTypedBean TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsInstanceFieldProducedBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsInstanceFieldProducedBeanByWrongTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsInstanceFieldProducedBeanByWrongTypes {
+
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.FIELD) TypedSuperInterface badSuperIface;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.FIELD) TypedTargetInterface goodIface;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.FIELD) TypedBaseType badSuperType;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.FIELD) TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsInstanceMethodProducedBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsInstanceMethodProducedBeanByWrongTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsInstanceMethodProducedBeanByWrongTypes {
+
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.METHOD) TypedSuperInterface badSuperIface;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.METHOD) TypedTargetInterface goodIface;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.METHOD) TypedBaseType badSuperType;
+  @Inject @QualForProducedTypeBean(isStatic=false, type=ProducerType.METHOD) TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsStaticFieldProducedBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsStaticFieldProducedBeanByWrongTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsStaticFieldProducedBeanByWrongTypes {
+
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.FIELD) TypedSuperInterface badSuperIface;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.FIELD) TypedTargetInterface goodIface;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.FIELD) TypedBaseType badSuperType;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.FIELD) TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsStaticMethodProducedBeanByWrongTypes.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/InjectsStaticMethodProducedBeanByWrongTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean;
+import org.jboss.errai.ioc.tests.wiring.client.res.QualForProducedTypeBean.ProducerType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedBaseType;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedSuperInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedTargetInterface;
+import org.jboss.errai.ioc.tests.wiring.client.res.TypedType;
+
+/**
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ */
+@Dependent
+public class InjectsStaticMethodProducedBeanByWrongTypes {
+
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.METHOD) TypedSuperInterface badSuperIface;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.METHOD) TypedTargetInterface goodIface;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.METHOD) TypedBaseType badSuperType;
+  @Inject @QualForProducedTypeBean(isStatic=true, type=ProducerType.METHOD) TypedType goodExactType;
+
+}

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/ParameterizedIface.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/ParameterizedIface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.unit.res;
 
 /**
- * @author Mike Brock
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+public interface ParameterizedIface<T> {
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/TypeParameterControlModule.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/TypeParameterControlModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,26 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.annotations.IOCProducer;
 
 /**
- * @author Mike Brock
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+@Dependent
+public class TypeParameterControlModule {
+
+  @Inject
+  public ParameterizedIface<Integer> val;
+
+  @IOCProducer
+  public static ParameterizedIface<String> produce() {
+    return null;
+  }
+
 }

--- a/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/TypeParameterTestModule.java
+++ b/errai-ioc/src/test/java/org/jboss/errai/ioc/unit/res/TypeParameterTestModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,30 @@
  * limitations under the License.
  */
 
-package org.jboss.errai.ioc.rebind.ioc.injector.api;
+package org.jboss.errai.ioc.unit.res;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.annotations.IOCProducer;
 
 /**
- * @author Mike Brock
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
  */
-public enum WiringElementType {
-  Type,
-  Specialization,
-  NormalScopedBean,
-  PseudoScopedBean,
-  JsType,
-  SharedSingleton,
-  LoadAsync,
-  DependentBean,
-  Simpleton, // TODO review name
-  Provider,
-  InjectionPoint,
-  ProducerElement,
-  AlternativeBean,
-  NotSupported
+@Dependent
+public class TypeParameterTestModule {
+
+  @SuppressWarnings("rawtypes")
+  @Inject
+  public ParameterizedIface rawTypedVal;
+
+  @Inject
+  public ParameterizedIface<Integer> typeArgsVal;
+
+  @IOCProducer
+  public static ParameterizedIface<String> produce() {
+    return null;
+  }
+
 }


### PR DESCRIPTION
Reintroduces support for `@Typed` and related refactoring.

The previous ERRAI-1018 commit that was reverted caused an infinite loop for apps injecting raw types. This PR includes tests protecting against this bug and related issues when injecting raw types.