### PR TITLE
Exclude el-api and interceptor-api from cdi-api

### DIFF
--- a/errai-ioc/pom.xml
+++ b/errai-ioc/pom.xml
@@ -95,6 +95,16 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.interceptor</groupId>
+          <artifactId>javax.interceptor-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Must come after errai-common is inherited for patched JUnitShell -->

--- a/errai-marshalling/pom.xml
+++ b/errai-marshalling/pom.xml
@@ -38,10 +38,20 @@
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.interceptor</groupId>
+          <artifactId>javax.interceptor-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
We should generally be using the JBoss Spec Jars. These excluded
deps does not seem to be needed, so there is no replacement
for those at this point.

@mbarkley WDYT about this? The other option would be to make it `<scope>provided</scope>`, as I guess we could assume the CDI will be provided by the application server?