### PR TITLE
Fixed List component destroyer initialization with Dependent scope

### DIFF
--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/ListComponentProvider.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/client/ListComponentProvider.java
@@ -57,7 +57,7 @@ public class ListComponentProvider implements ContextualTypeProvider<ListCompone
     final HTMLElement root = (HTMLElement) Document.get().createElement(listContainer.map(anno -> anno.value()).orElse("div"));
     final SyncBeanDef<?> beanDef = IOC.getBeanManager().lookupBean(typeargs[1], filteredQualifiers);
     final Supplier<?> supplier = () -> beanDef.getInstance();
-    final Consumer<?> destroyer = (Dependent.class.equals(beanDef.getScope()) ? c -> {} : c -> IOC.getBeanManager().destroyBean(c));
+    final Consumer<?> destroyer = (!Dependent.class.equals(beanDef.getScope()) ? c -> {} : c -> IOC.getBeanManager().destroyBean(c));
     final Function<?, HTMLElement> elementAccessor;
     if (beanDef.isAssignableTo(IsElement.class)) {
       elementAccessor = c -> ((IsElement) c).getElement();

--- a/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/TestModelWidget.java
+++ b/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/TestModelWidget.java
@@ -16,6 +16,7 @@
 
 package org.jboss.errai.databinding.client;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 
 import org.jboss.errai.common.client.api.annotations.IOCProducer;
@@ -34,6 +35,7 @@ import com.google.gwt.user.client.ui.Widget;
  */
 @Dependent
 public class TestModelWidget extends Widget implements HasValue<TestModel> {
+  public boolean destroyed=false;
 
   @IOCProducer
   @Qual
@@ -75,6 +77,15 @@ public class TestModelWidget extends Widget implements HasValue<TestModel> {
   @Override
   public void setValue(TestModel value, boolean fireEvents) {
     this.value = value;
+  }
+
+  @PreDestroy
+  public void setDestroyed(){
+      destroyed = true;
+  }
+
+  public boolean isDestroyed() {
+    return destroyed;
   }
 
   public boolean isQualified() {

--- a/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/ListBindingIntegrationTest.java
+++ b/errai-data-binding/src/test/java/org/jboss/errai/databinding/client/test/ListBindingIntegrationTest.java
@@ -90,6 +90,24 @@ public class ListBindingIntegrationTest extends AbstractErraiIOCTest {
 
     runTestModelListAssertions(list, component, one, two, three);
   }
+  public void testDeclarativeListHandlerBindingWithInjectedListDestroyerCallAfterRemove() throws Exception {
+    final ListComponentModule module = IOC.getBeanManager().lookupBean(ListComponentModule.class).getInstance();
+    final ListComponent<TestModel, TestModelWidget> component = module.list;
+    final TestModelWithListOfTestModels model = module.binder.getModel();
+    model.setList(new ArrayList<>());
+    final List<TestModel> list = model.getList();
+    final TestModel one = new TestModel("one");
+
+    list.add(one);
+    TestModelWidget testBean = component.getComponent(0);
+    assertFalse(component.getComponent(0).isQualified());
+    assertIndexOutOfBounds(component, 1);
+    assertFalse(testBean.isDestroyed());
+    list.remove(0);
+    assertTrue(testBean.isDestroyed());
+    assertIndexOutOfBounds(component, 0);
+
+  }
 
   public void testDeclarativeBindingDirectlyToList() throws Exception {
     final DirectBindingListComponentModule module = IOC.getBeanManager()


### PR DESCRIPTION
Changed the condition for the List Component destroyer initialization when its working with elements with Dependent scope 