### PR TITLE
errai-data-binding is a non-optional dependency for errai-ui

### DIFF
--- a/errai-ui/pom.xml
+++ b/errai-ui/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-data-binding</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
See https://github.com/errai/errai/issues/258