### PR TITLE
ERRAI-1049 Do not eat the WildFly/JBoss launcher exception

### DIFF
--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
@@ -38,7 +38,6 @@ import com.google.gwt.core.ext.ServletContainer;
 import com.google.gwt.core.ext.ServletContainerLauncher;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.TreeLogger.Type;
-import com.google.gwt.core.ext.UnableToCompleteException;
 
 /**
  * A {@link ServletContainerLauncher} controlling an embedded WildFly instance.
@@ -86,32 +85,26 @@ public class EmbeddedWildFlyLauncher extends ServletContainerLauncher {
   @Override
   public ServletContainer start(final TreeLogger treeLogger, final int port, final File appRootDir) throws BindException, Exception {
     logger = new StackTreeLogger(treeLogger);
-    try {
-      final String jbossHome = JBossUtil.getJBossHome(logger);
-      final String[] cmdArgs = JBossUtil.getCommandArguments(logger);
+    final String jbossHome = JBossUtil.getJBossHome(logger);
+    final String[] cmdArgs = JBossUtil.getCommandArguments(logger);
 
-      System.setProperty("jboss.http.port", "" + port);
+    System.setProperty("jboss.http.port", "" + port);
 
-      File cliConfigFile = new File(jbossHome, JBossUtil.CLI_CONFIGURATION_FILE);
-      if (cliConfigFile.exists()) {
-        System.setProperty("jboss.cli.config", cliConfigFile.getAbsolutePath());
-      }
-
-      final StandaloneServer embeddedWildFly = EmbeddedProcessFactory.createStandaloneServer(jbossHome, null,
-              new String[0], cmdArgs);
-      embeddedWildFly.start();
-
-      prepareBeansXml(appRootDir);
-      prepareUsersAndRoles(jbossHome);
-      JBossServletContainerAdaptor controller = new JBossServletContainerAdaptor(port, appRootDir,
-              JBossUtil.getDeploymentContext(), logger.peek(), null);
-
-      return controller;
+    File cliConfigFile = new File(jbossHome, JBossUtil.CLI_CONFIGURATION_FILE);
+    if (cliConfigFile.exists()) {
+      System.setProperty("jboss.cli.config", cliConfigFile.getAbsolutePath());
     }
-    catch (UnableToCompleteException e) {
-      logger.log(Type.ERROR, "Could not start servlet container controller", e);
-      throw new UnableToCompleteException();
-    }
+
+    final StandaloneServer embeddedWildFly = EmbeddedProcessFactory.createStandaloneServer(jbossHome, null,
+            new String[0], cmdArgs);
+    embeddedWildFly.start();
+
+    prepareBeansXml(appRootDir);
+    prepareUsersAndRoles(jbossHome);
+    JBossServletContainerAdaptor controller = new JBossServletContainerAdaptor(port, appRootDir,
+            JBossUtil.getDeploymentContext(), logger.peek(), null);
+
+    return controller;
   }
 
   /**

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/util/JBossUtil.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/util/JBossUtil.java
@@ -42,13 +42,11 @@ public class JBossUtil {
     final String JBOSS_HOME = System.getProperty(JBOSS_HOME_PROPERTY);
 
     if (JBOSS_HOME == null || JBOSS_HOME.equals("")) {
-      logger.log(
-              Type.ERROR,
+      throw new IllegalStateException(
               String.format(
                       "No value for %s was given: The root directory of your Jboss installation must be "
-                      + "provided through the property %s in your pom.xml",
+                      + "provided through the property %s in your pom.xml.",
                       JBOSS_HOME_PROPERTY, JBOSS_HOME_PROPERTY));
-      throw new UnableToCompleteException();
     }
 
     /*
@@ -66,18 +64,18 @@ public class JBossUtil {
     }
 
     if (!isValid) {
-      logger.branch(Type.ERROR, String.format(
-              "The errai.jboss.home directory, %s, does not appear to be home to a Jboss or Wildfly instance.",
-              JBOSS_HOME));
+      StringBuilder s = new StringBuilder();
+      s.append(String.format(
+              "The %s directory (%s) does not appear to be home to a JBoss or Wildfly instance.\n",
+              JBOSS_HOME_PROPERTY, JBOSS_HOME));
 
       for (int i = 0; i < files.length; i++) {
         if (!files[i].exists()) {
-          logger.log(Type.ERROR, String.format("%s not found.", files[i].getAbsolutePath()));
+          s.append(String.format("  %s not found.\n", files[i].getAbsolutePath()));
         }
       }
-      logger.unbranch();
 
-      throw new UnableToCompleteException();
+      throw new IllegalStateException(s.toString());
     }
 
     return JBOSS_HOME;


### PR DESCRIPTION
Replace
  log.error(error message for /dev/null);
  throw new UnableToCompleteException(no error message);
by
  throw new IllegalStateException(error message);

See the jira for motivation:
  https://issues.jboss.org/browse/ERRAI-1049