### PR TITLE
JBPM-5861: Added JsInterop support for constructing Blob types and for the Window.atob function.

### DIFF
--- a/errai-common/src/main/java/org/jboss/errai/common/client/dom/BlobImpl.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/dom/BlobImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.common.client.dom;
+
+import jsinterop.annotations.JsConstructor;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+/**
+ * A JsInterop blob type implementation which provides
+ * a public constructor.
+ */
+@JsType(isNative = true, name = "Blob", namespace = JsPackage.GLOBAL)
+public class BlobImpl implements Blob {
+
+    /**
+     * Factory method which creates a blob from plain string data.
+     * @param text The plain string text encoded as UFT-8.
+     * @return The blob instance.
+     */
+    @JsOverlay
+    public static BlobImpl create(final String text) {
+        return new BlobImpl(new String[]{text},
+                            BlobPropertyBag.createPlainTextType());
+    }
+
+    /**
+     * The blob's exported constructor.
+     * @param array Is an Array of ArrayBuffer, ArrayBufferView, Blob, DOMString objects,
+     * or a mix of any of such objects.
+     * @param options The BlobPropertyBag dictionary.
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob">Blob()</a>.
+     */
+    @JsConstructor
+    public BlobImpl(Object[] array,
+                    BlobPropertyBag options) {
+    }
+
+    @JsProperty
+    @Override
+    public native int getSize();
+
+    @JsProperty
+    @Override
+    public native String getType();
+
+    @Override
+    public native Blob slice();
+
+    @Override
+    public native Blob slice(int start);
+
+    @Override
+    public native Blob slice(int start,
+                             int end);
+
+    @Override
+    public native Blob slice(int start,
+                             int end,
+                             String contentType);
+}

--- a/errai-common/src/main/java/org/jboss/errai/common/client/dom/BlobPropertyBag.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/dom/BlobPropertyBag.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.common.client.dom;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+/**
+ * The Blob Property Bag.
+ * @see <a href="https://www.w3.org/TR/2012/WD-FileAPI-20121025/#dfn-BlobPropertyBag">BlobPropertyBag</a>
+ * <p>
+ * Notice looking at the docs, the IDL for the BlobPropertyBag specifies it as a dictionary, which at least
+ * must contain the <code>type</code> property.This way, the jsinterop type is being exported as
+ * an <code>Object</code> with a <code>type</code> property too.
+ */
+@JsType(isNative = true, name = "Object", namespace = JsPackage.GLOBAL)
+public class BlobPropertyBag {
+
+    @JsOverlay
+    public static String PLAIN_TEXT_UTF8 = "text/plain;charset=utf-8";
+    @JsOverlay
+    public static String IMAGE_JPG = "image/jpg";
+    @JsOverlay
+    public static String IMAGE_PNG = "image/png";
+
+    @JsOverlay
+    public static BlobPropertyBag create(final String type) {
+        final BlobPropertyBag blobPropertyBag = new BlobPropertyBag();
+        blobPropertyBag.setType(type);
+        return blobPropertyBag;
+    }
+
+    @JsOverlay
+    public static BlobPropertyBag createPlainTextType() {
+        return create(PLAIN_TEXT_UTF8);
+    }
+
+    @JsOverlay
+    public static BlobPropertyBag createImageJpgType() {
+        return create(IMAGE_JPG);
+    }
+
+    @JsOverlay
+    public static BlobPropertyBag createImagePngType() {
+        return create(IMAGE_PNG);
+    }
+
+    /**
+     * @return The ASCII-encoded string in lower case
+     * representing the media type of the Blob.
+     */
+    @JsProperty
+    public native String getType();
+
+    @JsProperty
+    public native void setType(String type);
+}

--- a/errai-common/src/main/java/org/jboss/errai/common/client/dom/Window.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/dom/Window.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Red Hat, Inc. and/or its affiliates.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,22 +16,32 @@
 
 package org.jboss.errai.common.client.dom;
 
-import org.jboss.errai.common.client.api.annotations.IOCProducer;
-
+import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
+import org.jboss.errai.common.client.api.annotations.IOCProducer;
 
 /**
- *
  * @author Max Barkley <mbarkley@redhat.com>
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window">Web API</a>
  */
 @JsType(isNative = true)
 public abstract class Window {
-  private Window() {}
 
-  @JsProperty(namespace = JsPackage.GLOBAL)
-  @IOCProducer
-  public static native Document getDocument();
+    private Window() {
+    }
+
+    @JsProperty(namespace = JsPackage.GLOBAL)
+    @IOCProducer
+    public static native Document getDocument();
+
+    /**
+     * Decodes a base-64 encoded string.
+     * @param encodedStr A string of base-64 encoded data.
+     * @return The decoded string data.
+     * @see <a href="https://www.w3schools.com/jsref/met_win_atob.asp">Window atob() Method</a>
+     */
+    @JsMethod(namespace = JsPackage.GLOBAL)
+    public static native String atob(String encodedStr);
 }


### PR DESCRIPTION
Hey @mbarkley !

This commit includes a few `jsinterop` types and methods, I need those to achieve some features from [this ticket](https://issues.jboss.org/browse/JBPM-5861).

Thanks!
Roger