### PR TITLE
AF-546: Reduce startup time of AppFormer apps and workbenches

### DIFF
--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/ErraiBus.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/ErraiBus.java
@@ -31,6 +31,8 @@ import org.jboss.errai.bus.client.api.messaging.MessageBus;
 import org.jboss.errai.bus.client.api.messaging.MessageCallback;
 import org.jboss.errai.bus.client.api.messaging.RequestDispatcher;
 import org.jboss.errai.common.client.api.extension.InitVotes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
@@ -41,67 +43,70 @@ import com.google.gwt.core.client.GWT;
  */
 public class ErraiBus implements EntryPoint {
   private static ClientMessageBus bus;
+  private static Logger logger = LoggerFactory.getLogger(ErraiBus.class);
 
   static {
     if (GWT.isClient()) {
+      logger.debug("Creating client message bus");
       bus = GWT.create(MessageBus.class);
     }
     else {
 
+      logger.debug("Creating simulated client message bus");
       // edge case: in simulated client mode, client code runs in an environment where GWT.isClient() returns false
       // obviously, this code will not be able to contact the server, but framework code still assumes bus != null
       bus = new ClientMessageBus() {
         @Override
-        public void sendGlobal(Message message) {
+        public void sendGlobal(final Message message) {
 
         }
 
         @Override
-        public void send(Message message) {
+        public void send(final Message message) {
         }
 
         @Override
-        public void send(Message message, boolean fireListeners) {
+        public void send(final Message message, final boolean fireListeners) {
         }
 
         @Override
-        public void sendLocal(Message message) {
+        public void sendLocal(final Message message) {
         }
 
         @Override
-        public Subscription subscribe(String subject, MessageCallback receiver) {
+        public Subscription subscribe(final String subject, final MessageCallback receiver) {
           return null;
         }
 
         @Override
-        public Subscription subscribeLocal(String subject, MessageCallback receiver) {
+        public Subscription subscribeLocal(final String subject, final MessageCallback receiver) {
           return null;
         }
 
         @Override
-        public Subscription subscribeShadow(String subject, MessageCallback callback) {
+        public Subscription subscribeShadow(final String subject, final MessageCallback callback) {
           return null;
         }
 
         @Override
-        public void unsubscribeAll(String subject) {
+        public void unsubscribeAll(final String subject) {
         }
 
         @Override
-        public boolean isSubscribed(String subject) {
+        public boolean isSubscribed(final String subject) {
           return false;
         }
 
         @Override
-        public void addSubscribeListener(SubscribeListener listener) {
+        public void addSubscribeListener(final SubscribeListener listener) {
         }
 
         @Override
-        public void addUnsubscribeListener(UnsubscribeListener listener) {
+        public void addUnsubscribeListener(final UnsubscribeListener listener) {
         }
 
         @Override
-        public void attachMonitor(BusMonitor monitor) {
+        public void attachMonitor(final BusMonitor monitor) {
         }
 
         @Override
@@ -109,7 +114,7 @@ public class ErraiBus implements EntryPoint {
         }
 
         @Override
-        public void stop(boolean sendDisconnectToServer) {
+        public void stop(final boolean sendDisconnectToServer) {
         }
 
         @Override
@@ -118,23 +123,23 @@ public class ErraiBus implements EntryPoint {
         }
 
         @Override
-        public void addTransportErrorHandler(TransportErrorHandler errorHandler) {
+        public void addTransportErrorHandler(final TransportErrorHandler errorHandler) {
         }
 
         @Override
-        public void removeTransportErrorHandler(TransportErrorHandler errorHandler) {
+        public void removeTransportErrorHandler(final TransportErrorHandler errorHandler) {
         }
 
         @Override
-        public void addLifecycleListener(BusLifecycleListener l) {
+        public void addLifecycleListener(final BusLifecycleListener l) {
         }
 
         @Override
-        public void removeLifecycleListener(BusLifecycleListener l) {
+        public void removeLifecycleListener(final BusLifecycleListener l) {
         }
 
         @Override
-        public void setProperty(String name, String value) {
+        public void setProperty(final String name, final String value) {
         }
 
         @Override
@@ -156,6 +161,7 @@ public class ErraiBus implements EntryPoint {
     InitVotes.registerPersistentPreInitCallback(new Runnable() {
       @Override
       public void run() {
+        logger.debug("Initializing client message bus.");
         bus.init();
       }
     });
@@ -172,12 +178,12 @@ public class ErraiBus implements EntryPoint {
 
   private static RequestDispatcher DISPATCHER_INST = new RequestDispatcher() {
     @Override
-    public void dispatchGlobal(Message message) {
+    public void dispatchGlobal(final Message message) {
       get().sendGlobal(message);
     }
 
     @Override
-    public void dispatch(Message message) {
+    public void dispatch(final Message message) {
       get().send(message);
     }
   };

--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/framework/ClientMessageBusImpl.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/framework/ClientMessageBusImpl.java
@@ -382,6 +382,7 @@ public class ClientMessageBusImpl implements ClientMessageBus {
       directSubscribe(BuiltInServices.ClientBus.name(), protocolCommandCallback, false);
     }
 
+    loadRpcProxies();
     // The purpose of this timer is to let the bus yield and give other modules a chance to register
     // services before we send our state synchronization message. This is not strictly necessary
     // but significantly decreases network chattiness since more (if not all known services)
@@ -389,7 +390,7 @@ public class ClientMessageBusImpl implements ClientMessageBus {
     initialConnectTimer = new Timer() {
       @Override
       public void run() {
-        loadRpcProxies();
+        logger.debug("Bus initialization timer running...");
         sendInitialMessage();
       }
     };

--- a/errai-common/src/main/java/org/jboss/errai/common/client/api/extension/InitVotes.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/api/extension/InitVotes.java
@@ -51,17 +51,17 @@ import com.google.gwt.core.client.GWT;
 public final class InitVotes {
   private InitVotes() {}
 
-  private static final List<Runnable> preInitCallbacks = new ArrayList<Runnable>();
-  private static final Map<String, List<Runnable>> dependencyCallbacks = new HashMap<String, List<Runnable>>();
-  private static final List<Runnable> initCallbacks = new ArrayList<Runnable>();
-  private static final List<InitFailureListener> initFailureListeners = new ArrayList<InitFailureListener>();
+  private static final List<Runnable> preInitCallbacks = new ArrayList<>();
+  private static final Map<String, List<Runnable>> dependencyCallbacks = new HashMap<>();
+  private static final List<Runnable> initCallbacks = new ArrayList<>();
+  private static final List<InitFailureListener> initFailureListeners = new ArrayList<>();
 
   private static boolean armed = false;
   private static boolean init = false;
-  private static final Set<String> waitForSet = new HashSet<String>();
+  private static final Set<String> waitForSet = new HashSet<>();
 
   // a list of both strings and runnable references that are marked done.
-  private static final Set<Object> completedSet = new HashSet<Object>();
+  private static final Set<Object> completedSet = new HashSet<>();
 
   private static int timeoutMillis = !GWT.isProdMode() ? 90000 : 45000;
 
@@ -194,17 +194,21 @@ public final class InitVotes {
   private static void scheduleFinish() {
     if (_initWait)
       return;
+
+    logger.debug("Scheduling finish.");
     _initWait = true;
 
     _scheduleFinish(new Runnable() {
       @Override
       public void run() {
+        logger.debug("Running finish timer...");
         if (armed && waitForSet.isEmpty()) {
           idempotentStopFailTimer();
           finishInit();
           _initWait = false;
         }
         else {
+          logger.debug("Rescheduling finish.");
           _scheduleFinish(this);
         }
       }
@@ -227,7 +231,7 @@ public final class InitVotes {
     synchronized (lock) {
       List<Runnable> callbacks = dependencyCallbacks.get(topic);
       if (callbacks == null) {
-        dependencyCallbacks.put(topic, callbacks = new ArrayList<Runnable>());
+        dependencyCallbacks.put(topic, callbacks = new ArrayList<>());
       }
       if (!callbacks.contains(runnable)) {
         callbacks.add(runnable);
@@ -308,6 +312,7 @@ public final class InitVotes {
       logger.warn("did not start polling. already armed.");
       return;
     }
+    logger.info("Starting init polling.");
     timeoutMillis = getConfiguredTimeoutOrElse(timeoutMillis);
     beginInit();
   }
@@ -331,7 +336,7 @@ public final class InitVotes {
 
             idempotentStopDelayTimer();
 
-            final Set<String> failedTopics = Collections.unmodifiableSet(new HashSet<String>(waitForSet));
+            final Set<String> failedTopics = Collections.unmodifiableSet(new HashSet<>(waitForSet));
             _fireFailedInit(failedTopics);
 
             logger.error("components failed to initialize");
@@ -354,6 +359,7 @@ public final class InitVotes {
 
   private static void finishInit() {
     synchronized (lock) {
+      logger.debug("Finishing initialization...");
       armed = false;
       init = true;
       idempotentStopFailTimer();
@@ -381,12 +387,12 @@ public final class InitVotes {
   private static void _runAllRunnables(final List<Runnable> runnables) {
     if (runnables == null || runnables.isEmpty())
       return;
-    _runAllRunnables(new ArrayList<Runnable>(runnables), runnables);
+    _runAllRunnables(new ArrayList<>(runnables), runnables);
 
   }
 
   private static void _runAllRunnables(final List<Runnable> curRunnables, final List<Runnable> allRunnables) {
-    for (Runnable runnable : curRunnables) {
+    for (final Runnable runnable : curRunnables) {
       if (completedSet.contains(runnable)) {
         continue;
       }
@@ -395,11 +401,11 @@ public final class InitVotes {
       if (runnable instanceof OneTimeRunnable) {
         allRunnables.remove(runnable);
       }
-      int expectedSize = allRunnables.size();
+      final int expectedSize = allRunnables.size();
       runnable.run();
       if (expectedSize < allRunnables.size()) {
         // this runnable added more runnables that need to be executed
-        List<Runnable> moreRunnables = new ArrayList<Runnable>(allRunnables).subList(expectedSize, allRunnables.size());
+        final List<Runnable> moreRunnables = new ArrayList<>(allRunnables).subList(expectedSize, allRunnables.size());
         _runAllRunnables(moreRunnables, allRunnables);
       }
     }
@@ -418,7 +424,7 @@ public final class InitVotes {
   private static class OneTimeRunnable implements Runnable {
     private final Runnable delegate;
 
-    private OneTimeRunnable(Runnable delegate) {
+    private OneTimeRunnable(final Runnable delegate) {
       this.delegate = delegate;
     }
 

--- a/errai-common/src/main/java/org/jboss/errai/common/client/logging/LoggingHandlerConfigurator.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/logging/LoggingHandlerConfigurator.java
@@ -39,31 +39,31 @@ import com.google.gwt.logging.client.HasWidgetsLogHandler;
  * <li>{@link ErraiConsoleLogHandler}: Logs to web console.</li>
  * <li>{@link ErraiDevelopmentModeLogHandler}: Logs to Dev Mode window.</li>
  * </ul>
- * 
+ *
  * By default these handlers use the {@link ErraiSimpleFormatter} to format
  * output.
- * 
+ *
  * @author Max Barkley <mbarkley@redhat.com>
  */
 public class LoggingHandlerConfigurator implements EntryPoint {
 
-  private Map<Class<? extends ErraiLogHandler>, Handler> handlers = new HashMap<Class<? extends ErraiLogHandler>, Handler>();
+  private final Map<Class<? extends ErraiLogHandler>, Handler> handlers = new HashMap<>();
   private static LoggingHandlerConfigurator instance;
 
   @Override
   public void onModuleLoad() {
     final Logger logger = Logger.getLogger("");
-    
+
     // FIXME temporary workaround for
     // https://groups.google.com/forum/#!topic/google-web-toolkit/Sd9P0UjUyRA
-   
+
     // We had to remove <set-property name="gwt.logging.popupHandler"
     // value="DISABLED"/> for GWT 2.7 compatibility but don't want to annoy our
     // users on older GWT versions with the pop-up window or force them to
     // disable the logger themselves.
-    Handler[] logHandlers = logger.getHandlers();
+    final Handler[] logHandlers = logger.getHandlers();
     if (logHandlers != null) {
-      for (Handler logHandler : logHandlers) {
+      for (final Handler logHandler : logHandlers) {
         if (logHandler instanceof HasWidgetsLogHandler) {
           logger.removeHandler(logHandler);
           ((HasWidgetsLogHandler)logHandler).clear();
@@ -93,13 +93,13 @@ public class LoggingHandlerConfigurator implements EntryPoint {
   /**
    * Get the top-level Errai log handlers. This could be useful if you wish to
    * change the {@link Level} or {@link Formatter} of a handler.
-   * 
+   *
    * @param handlerType
    *          The type of an {@link ErraiLogHandler}.
    * @return The active {@link Handler} of the requested type.
    */
   @SuppressWarnings("unchecked")
-  public <H extends ErraiLogHandler> H getHandler(Class<H> handlerType) {
+  public <H extends ErraiLogHandler> H getHandler(final Class<H> handlerType) {
     return (H) handlers.get(handlerType);
   }
 

--- a/errai-marshalling/src/main/java/org/jboss/errai/marshalling/client/api/MarshallerFramework.java
+++ b/errai-marshalling/src/main/java/org/jboss/errai/marshalling/client/api/MarshallerFramework.java
@@ -26,6 +26,8 @@ import org.jboss.errai.marshalling.client.api.json.EJObject;
 import org.jboss.errai.marshalling.client.api.json.EJValue;
 import org.jboss.errai.marshalling.client.api.json.impl.gwt.GWTJSON;
 import org.jboss.errai.marshalling.client.protocols.MarshallingSessionProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
@@ -36,8 +38,10 @@ import com.google.gwt.json.client.JSONParser;
  */
 public class MarshallerFramework implements EntryPoint {
   private static MarshallerFactory marshallerFactory;
+  private static Logger logger = LoggerFactory.getLogger(MarshallerFramework.class);
 
   static {
+    logger.debug("Initializing marshalling framework...");
     InitVotes.waitFor(MarshallerFramework.class);
     marshallerFactory = GWT.create(MarshallerFactory.class);
 
@@ -79,7 +83,7 @@ public class MarshallerFramework implements EntryPoint {
         }
 
         @Override
-        public void registerMarshaller(String fqcn, Marshaller m) {
+        public void registerMarshaller(final String fqcn, final Marshaller m) {
           MarshallerFramework.getMarshallerFactory().registerMarshaller(fqcn, m);
         }
       });


### PR DESCRIPTION
This commit:
* Adds logging to audit startup to entrypoints, RPCs, bean manager
* Load RPC proxies before the bus initializes so that startup RPC calls
can be queued up and sent in a single payload
* Don't wait for bus to initialize to send CDI client associate message
(allows this to also be sent with initial bus payload)
* Don't delay InitVotes in SecurityContextImpl if a user has been injected
onto the host page