### PR TITLE
JBPM-6207: [Forms Modeler] Slider based properties throw null exception

### DIFF
--- a/errai-common/src/main/java/org/jboss/errai/common/client/dom/DOMUtil.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/dom/DOMUtil.java
@@ -317,9 +317,9 @@ public abstract class DOMUtil {
     if (child.isAttached()) {
       child.removeFromParent();
     }
-    onAttach(child);
     RootPanel.detachOnWindowClose(child);
     parent.appendChild(nativeCast(child.getElement()));
+    onAttach(child);
   }
 
   /**


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-6207

```DOMUtils``` was calling ```Widget.onAttach()``` before it was attached to a parent. This leads to problems with 3rd party controls (in this specific case Bootstrap's "[Slider](https://github.com/seiyria/bootstrap-slider)" control) that require the Widget's parent element to be [set](https://github.com/seiyria/bootstrap-slider/blob/master/src/js/bootstrap-slider.js#L434) when ```onLoad()``` (called by ```onAttach()```) is called.. 