### PR TITLE
Fix Jenkins CI build

### DIFF
--- a/errai-client-local-class-hider/pom.xml
+++ b/errai-client-local-class-hider/pom.xml
@@ -26,12 +26,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>      
     </dependency>
@@ -78,20 +72,5 @@
       </plugin>
     </plugins>
   </build>
-  
-  <!-- DistributionManagement -->
-  <distributionManagement>
-    <repository>
-      <id>jboss-releases-repository</id>
-      <name>JBoss Releases Repository</name>
-      <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
-    </repository>
 
-    <snapshotRepository>
-      <id>jboss-snapshots-repository</id>
-      <name>JBoss Snapshots Repository</name>
-      <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
-  
 </project>

--- a/errai-demos/errai-security-demo/pom.xml
+++ b/errai-demos/errai-security-demo/pom.xml
@@ -62,6 +62,7 @@
     <javaee.version>3.0.1.Final</javaee.version>
     <errai.dev.context>${project.artifactId}</errai.dev.context>
     <maven.gwt.plugin.version>2.8.0</maven.gwt.plugin.version>
+    <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>
   </properties>
 
   <repositories>
@@ -308,6 +309,14 @@
           <soyc>false</soyc>
           <hostedWebapp>src/main/webapp</hostedWebapp>
           <extraJvmArgs>-Xmx1G -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.dev.context=${errai.dev.context}</extraJvmArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${maven.deploy.plugin.version}</version>
+        <configuration>
+          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/errai-forge-addon/pom.xml
+++ b/errai-forge-addon/pom.xml
@@ -246,4 +246,19 @@
       </build>
     </profile>
   </profiles>
+
+  <distributionManagement>
+    <repository>
+      <id>jboss-releases-repository</id>
+      <name>JBoss Releases Repository</name>
+      <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
+    </repository>
+
+    <snapshotRepository>
+      <id>jboss-snapshots-repository</id>
+      <name>JBoss Snapshots Repository</name>
+      <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
 </project>

--- a/errai-jboss-as-support/pom.xml
+++ b/errai-jboss-as-support/pom.xml
@@ -25,12 +25,6 @@
       <artifactId>jboss-vfs</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
- Adding deployment skip configuration to `errai-demos/errai-security-demo` module.

- Adding `<distributionManagement />` configuration to `errai-forge-addon` module.

- Removing unnecessary `<distributionManagement />` configuration in `errai-client-local-class-hider` because it's inherited from `org.jboss:jboss-parent`. _(not necessary to fix Jenkins CI build)_

- Removing unnecessary dependency `junit:junit` in `errai-client-local-class-hider` because it's inherited from `errai-parent`. _(not necessary to fix Jenkins CI build)_