### PR TITLE
Fix TableCell tag name mapping

### DIFF
--- a/errai-common/src/main/java/org/jboss/errai/common/client/dom/TableCell.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/dom/TableCell.java
@@ -29,7 +29,8 @@ import jsinterop.annotations.JsType;
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableCellElement">Web API</a>
  */
 @JsType(isNative = true)
-@Element({"tr", "td"})
+@Element({"th", "td"})
+@Deprecated
 public interface TableCell extends HTMLElement {
   @JsProperty int getCellIndex();
 


### PR DESCRIPTION
This was already made in https://github.com/errai/errai/pull/282 but have been mistakenly overriden by https://github.com/errai/errai/pull/286.