### PR TITLE
Implementation of ContentDelegation interface

### DIFF
--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.errai.ui.nav.client.local;
 
 import com.google.gwt.user.client.ui.IsWidget;

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
@@ -5,13 +5,32 @@ import org.jboss.errai.ui.nav.client.local.api.DelegationControl;
 
 /**
  * Content delegation control interface.
+ *
  * @author Ben Dol
  */
 public interface ContentDelegation {
 
+    /**
+     * Called when the page is showing its content (setting the container widget).
+     *
+     * @param page the current page being shown.
+     * @param defaultContainer the default content container.
+     * @param widget the widget reference object for the page.
+     * @param previousPage the previous page, <b>this can be null</b>.
+     * @param control the delegation control for proceeding navigation process.
+     */
     void showContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, Object previousPage,
                      DelegationControl control);
 
+    /**
+     * Called when the page is hiding its content (clearing container).
+     *
+     * @param page the current page being hidden.
+     * @param defaultContainer the default content container.
+     * @param widget the widget reference object for the page.
+     * @param nextPage potential next requested page, <b>this can be null</b>.
+     * @param control the delegation control for proceeding navigation process.
+     */
     void hideContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, Object nextPage,
                      DelegationControl control);
 }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
@@ -1,0 +1,11 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.ui.nav.client.local.spi.PageNode;
+
+public interface ContentDelegation {
+
+    void showContent(PageNode<Object> page, NavigatingContainer container, IsWidget widget);
+
+    void hideContent(PageNode<Object> page, NavigatingContainer container, IsWidget widget);
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
@@ -1,14 +1,17 @@
 package org.jboss.errai.ui.nav.client.local;
 
 import com.google.gwt.user.client.ui.IsWidget;
-import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
-import org.jboss.errai.ui.nav.client.local.spi.PageNode;
+import org.jboss.errai.ui.nav.client.local.api.DelegationControl;
 
+/**
+ * Content delegation control interface.
+ * @author Ben Dol
+ */
 public interface ContentDelegation {
 
-    void showContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, PageNode<?> previousPage,
-                     NavigationControl control);
+    void showContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, Object previousPage,
+                     DelegationControl control);
 
-    void hideContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, PageNode<?> nextPage,
-                     NavigationControl control);
+    void hideContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, Object nextPage,
+                     DelegationControl control);
 }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/ContentDelegation.java
@@ -1,11 +1,14 @@
 package org.jboss.errai.ui.nav.client.local;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
 import org.jboss.errai.ui.nav.client.local.spi.PageNode;
 
 public interface ContentDelegation {
 
-    void showContent(PageNode<Object> page, NavigatingContainer container, IsWidget widget);
+    void showContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, PageNode<?> previousPage,
+                     NavigationControl control);
 
-    void hideContent(PageNode<Object> page, NavigatingContainer container, IsWidget widget);
+    void hideContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, PageNode<?> nextPage,
+                     NavigationControl control);
 }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
@@ -2,8 +2,6 @@ package org.jboss.errai.ui.nav.client.local;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import org.jboss.errai.ui.nav.client.local.api.DelegationControl;
-import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
-import org.jboss.errai.ui.nav.client.local.spi.PageNode;
 
 /**
  * Default content delegation procedure.

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
@@ -1,21 +1,26 @@
 package org.jboss.errai.ui.nav.client.local;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.ui.nav.client.local.api.DelegationControl;
 import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
 import org.jboss.errai.ui.nav.client.local.spi.PageNode;
 
+/**
+ * Default content delegation procedure.
+ * @author Ben Dol
+ */
 public class DefaultContentDelegation implements ContentDelegation {
 
     @Override
-    public void showContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, PageNode<?> previousPage,
-                            NavigationControl control) {
+    public void showContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, Object previousPage,
+                            DelegationControl control) {
         defaultContainer.setWidget(widget);
         control.proceed();
     }
 
     @Override
-    public void hideContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, PageNode<?> nextPage,
-                            NavigationControl control) {
+    public void hideContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, Object nextPage,
+                            DelegationControl control) {
         defaultContainer.clear();
         control.proceed();
     }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.errai.ui.nav.client.local;
 
 import com.google.gwt.user.client.ui.IsWidget;

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
@@ -1,0 +1,17 @@
+package org.jboss.errai.ui.nav.client.local;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.ui.nav.client.local.spi.PageNode;
+
+public class DefaultContentDelegation implements ContentDelegation {
+
+    @Override
+    public void showContent(PageNode<Object> page, NavigatingContainer container, IsWidget widget) {
+        container.setWidget(widget);
+    }
+
+    @Override
+    public void hideContent(PageNode<Object> page, NavigatingContainer container, IsWidget widget) {
+        container.clear();
+    }
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultContentDelegation.java
@@ -1,17 +1,22 @@
 package org.jboss.errai.ui.nav.client.local;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
 import org.jboss.errai.ui.nav.client.local.spi.PageNode;
 
 public class DefaultContentDelegation implements ContentDelegation {
 
     @Override
-    public void showContent(PageNode<Object> page, NavigatingContainer container, IsWidget widget) {
-        container.setWidget(widget);
+    public void showContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, PageNode<?> previousPage,
+                            NavigationControl control) {
+        defaultContainer.setWidget(widget);
+        control.proceed();
     }
 
     @Override
-    public void hideContent(PageNode<Object> page, NavigatingContainer container, IsWidget widget) {
-        container.clear();
+    public void hideContent(Object page, NavigatingContainer defaultContainer, IsWidget widget, PageNode<?> nextPage,
+                            NavigationControl control) {
+        defaultContainer.clear();
+        control.proceed();
     }
 }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
@@ -40,6 +40,7 @@ import org.jboss.errai.ioc.client.lifecycle.api.Access;
 import org.jboss.errai.ioc.client.lifecycle.api.LifecycleCallback;
 import org.jboss.errai.ioc.client.lifecycle.api.StateChange;
 import org.jboss.errai.ioc.client.lifecycle.impl.AccessImpl;
+import org.jboss.errai.ui.nav.client.local.api.DelegationControl;
 import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
 import org.jboss.errai.ui.nav.client.local.api.PageNavigationErrorHandler;
 import org.jboss.errai.ui.nav.client.local.api.PageNotFoundException;
@@ -372,7 +373,7 @@ public class Navigation {
    *
    * @param requestPage the next requested page, this can be null if there is none.
    */
-  private void hideCurrentPage(PageNode<?> requestPage, NavigationControl control) {
+  private void hideCurrentPage(Object requestPage, NavigationControl control) {
     final IsWidget currentContent = navigatingContainer.getWidget();
 
     // Note: Optimized out in production mode
@@ -382,7 +383,7 @@ public class Navigation {
             + ".");
     }
 
-    NavigationControl hideControl = new NavigationControl(this, () -> {
+    DelegationControl hideControl = new DelegationControl(() -> {
       if (currentPage != null && currentComponent != null) {
         currentPage.pageHidden(currentComponent);
         currentPage.destroy(currentComponent);
@@ -476,11 +477,11 @@ public class Navigation {
                     // fields actually changed.
                     stateChangeEvent.fireAsync(component);
 
-                    PageNode<?> previousPage = currentPage;
+                    Object previousPage = currentComponent;
                     setCurrentPage(request.pageNode);
                     currentWidget = componentWidget;
                     currentComponent = component;
-                    contentDelegation.showContent(component, navigatingContainer, currentWidget, previousPage, new NavigationControl(Navigation.this, () -> {
+                    contentDelegation.showContent(component, navigatingContainer, currentWidget, previousPage, new DelegationControl(() -> {
                       request.pageNode.pageShown(component, request.state);
                     }));
                   } finally {
@@ -498,7 +499,7 @@ public class Navigation {
 
               try {
                 locked = true;
-                hideCurrentPage(request.pageNode, new NavigationControl(Navigation.this, () -> {
+                hideCurrentPage(component, new NavigationControl(Navigation.this, () -> {
                   request.pageNode.pageShowing(component, request.state, showControl);
                 }));
               } catch (Exception ex) {

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
@@ -392,7 +392,7 @@ public class Navigation {
       control.proceed();
     });
 
-    if(currentComponent != null) {
+    if (currentComponent != null) {
       contentDelegation.hideContent(currentComponent, navigatingContainer, currentWidget, requestPage, hideControl);
     } else {
       navigatingContainer.clear();

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
@@ -118,6 +118,8 @@ public class Navigation {
 
   protected HistoryToken currentPageToken;
 
+  protected ContentDelegation contentDelegation = new DefaultContentDelegation();
+
   private PageNavigationErrorHandler navigationErrorHandler;
 
   private HandlerRegistration historyHandlerRegistration;
@@ -375,11 +377,10 @@ public class Navigation {
     if (currentPage != null && (currentContent == null || currentWidget.asWidget() != currentContent)) {
       // This could happen if someone was manipulating the DOM behind our backs
       GWT.log("Current content widget vanished or changed. " + "Not delivering pageHiding event to " + currentPage
-              + ".");
+            + ".");
     }
 
-    // Ensure clean contentPanel regardless of currentPage being null
-    navigatingContainer.clear();
+    contentDelegation.hideContent(currentPage, navigatingContainer, currentWidget);
 
     if (currentPage != null && currentComponent != null) {
       currentPage.pageHidden(currentComponent);
@@ -388,7 +389,8 @@ public class Navigation {
   }
 
   /**
-   * Call navigation and page related lifecycle methods. If the {@link Access} is fired successfully, load the new page.
+   * Call navigation and page related lifecycle methods.
+   * If the {@link Access} is fired successfully, load the new page.
    */
   private <C> void maybeShowPage(final Request<C> request, final boolean fireEvent) {
     request.pageNode.produceContent(component -> {
@@ -466,7 +468,7 @@ public class Navigation {
                     setCurrentPage(request.pageNode);
                     currentWidget = componentWidget;
                     currentComponent = component;
-                    navigatingContainer.setWidget(componentWidget);
+                    contentDelegation.showContent(currentPage, navigatingContainer, currentWidget);
                     request.pageNode.pageShown(component, request.state);
                   } finally {
                     locked = false;
@@ -628,4 +630,8 @@ public class Navigation {
   private native static IsWidget getCompositeWidget(Composite instance) /*-{
       return instance.@com.google.gwt.user.client.ui.Composite::widget;
   }-*/;
+
+  public void setContentDelegation(ContentDelegation contentDelegation) {
+    this.contentDelegation = contentDelegation;
+  }
 }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/api/DelegationControl.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/api/DelegationControl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.nav.client.local.api;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import org.jboss.errai.ui.nav.client.local.Navigation;
+import org.jboss.errai.ui.nav.client.local.PageHiding;
+
+/**
+ * Instances of this class are passed to the {@link org.jboss.errai.ui.nav.client.local.ContentDelegation}.
+ */
+public class DelegationControl {
+
+  private final Runnable runnable;
+
+  private boolean hasRun;
+
+  public DelegationControl(final Runnable runnable) {
+    this.runnable = runnable;
+  }
+
+  /**
+   * Causes page navigation to proceed.
+   */
+  public void proceed() {
+    if (!hasRun) {
+      runnable.run();
+      hasRun = true;
+    }
+    else {
+      throw new IllegalStateException("proceed() method can only be called once.");
+    }
+  }
+
+  public boolean hasRun() {
+    return hasRun;
+  }
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/api/DelegationControl.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/api/DelegationControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,6 @@
  */
 
 package org.jboss.errai.ui.nav.client.local.api;
-
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
-import org.jboss.errai.ui.nav.client.local.Navigation;
-import org.jboss.errai.ui.nav.client.local.PageHiding;
 
 /**
  * Instances of this class are passed to the {@link org.jboss.errai.ui.nav.client.local.ContentDelegation}.

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/api/NavigationControl.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/api/NavigationControl.java
@@ -37,8 +37,8 @@ public class NavigationControl {
   private boolean hasRun;
 
   public NavigationControl(final Navigation navigation, final Runnable runnable) {
-    this.runnable = runnable;
     this.navigation = navigation;
+    this.runnable = runnable;
   }
 
   public NavigationControl(final Navigation navigation, final Runnable runnable, Runnable interrupt) {

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/BasePageForLifecycleTracing.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/BasePageForLifecycleTracing.java
@@ -80,7 +80,7 @@ public class BasePageForLifecycleTracing extends HorizontalPanel {
   @PageShowing
   protected void beforeShow() {
     lifecycleTracer.add(new Record(PageShowing.class));
-     doRedirect();
+    doRedirect();
   }
 
   @PageShown


### PR DESCRIPTION
This opens the door for custom content management using the ContentDelegation hooks.

It means we can create our our own multi-container layer app where certain content can be delegated to their own containers. It also allows for us to implement our own page transitions.

```java
navigation.setContentDelegation(new MyPageDelegation());
```

When the content is being set or cleared we have control over the process with this PR.

Let me know if there are any suggestions or nit picks and I can update the PR asap.

Thanks!