### PR TITLE
AF-477: Support for Window's confirm method.

### DIFF
--- a/errai-common/src/main/java/org/jboss/errai/common/client/dom/Window.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/dom/Window.java
@@ -47,4 +47,14 @@ public abstract class Window {
      */
     @JsMethod(namespace = JsPackage.GLOBAL)
     public static native String atob(String encodedStr);
+
+    /**
+     * Displays a dialog box with a specified message, along with an OK and a Cancel button.
+     * @param message Specifies the text to display in the confirm box.
+     * @return true if the user clicked "OK", return false otherwise.
+     * @see <a href="https://www.w3schools.com/jsref/met_win_confirm.asp">Window confirm() Method</a>
+     */
+    @JsMethod(namespace = JsPackage.GLOBAL)
+    public static native boolean confirm(String message);
+
 }


### PR DESCRIPTION
Hey @mbarkley ,
As commented before, adding the `confirm` method in the Window object API because this needs to be back-ported to `7.3.x`/`4.0.x`. 
Thanks! 