### PR TITLE
Add errai.bus.web_socket_max_frame_size property

### DIFF
--- a/errai-bus/src/main/java/org/jboss/errai/bus/server/io/websockets/WebSocketServerHandler.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/server/io/websockets/WebSocketServerHandler.java
@@ -76,6 +76,7 @@ import org.jboss.errai.bus.client.protocols.BusCommand;
 import org.jboss.errai.bus.server.api.MessageQueue;
 import org.jboss.errai.bus.server.io.DirectDeliveryHandler;
 import org.jboss.errai.bus.server.io.MessageFactory;
+import org.jboss.errai.bus.server.service.ErraiConfigAttribs;
 import org.jboss.errai.bus.server.service.ErraiService;
 import org.jboss.errai.bus.server.util.LocalContext;
 import org.jboss.errai.common.client.protocols.MessageParts;
@@ -125,9 +126,11 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler {
       return;
     }
 
+    int maxFrameSize = ErraiConfigAttribs.WEB_SOCKET_MAX_FRAME_SIZE.getInt(svc.getConfiguration());
+
     // Handshake
     final WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(
-        this.getWebSocketLocation(req), null, false);
+        this.getWebSocketLocation(req), null, false, maxFrameSize);
     this.handshaker = wsFactory.newHandshaker(req);
     if (this.handshaker == null) {
       wsFactory.sendUnsupportedWebSocketVersionResponse(ctx.channel());

--- a/errai-bus/src/main/java/org/jboss/errai/bus/server/service/ErraiConfigAttribs.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/server/service/ErraiConfigAttribs.java
@@ -81,6 +81,7 @@ public enum ErraiConfigAttribs {
   WEB_SOCKET_KEYSTORE_TYPE("errai.bus.web_socket_keystore_type", "JKS"),
   WEB_SOCKET_KEYSTORE_PASSWORD("errai.bus.web_socket_keystore_password"),
   WEB_SOCKET_KEY_PASSWORD("errai.bus.web_socket_key_password"),
+  WEB_SOCKET_MAX_FRAME_SIZE("errai.bus.web_socket_max_frame_size", "65536"),
 
   WEBSOCKET_SERVLET_ENABLED("errai.bus.websocket.servlet.enabled", "false"),
   WEBSOCKET_SERVLET_CONTEXT_PATH("errai.bus.websocket.servlet.path", "in.erraiBusWebSocket"),


### PR DESCRIPTION
Required to expand the default websocket frame size.

Pretty simple change, please let me know if there is a better implementation.

Thanks!