### PR TITLE
upgraded to jboss-ip-bom 8.0.0.CR2

### DIFF
--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
-    <version>7.0.0.CR9</version>
+    <version>8.0.0.CR2</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
-    <version>7.0.0.CR9</version>
+    <version>8.0.0.CR2</version>
   </parent>
 
   <name>Errai</name>


### PR DESCRIPTION
@mbarkley we have to update Errai for BxMS 7.0.0.DR1 because of the alignment to EAP 7.1 CR3.
Therefor we also need a new release of Errai (master)