### PR TITLE
Add Elemental2DomUtil (utility methods for interacting with the DOM)

### DIFF
--- a/errai-common/pom.xml
+++ b/errai-common/pom.xml
@@ -96,6 +96,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.elemental2</groupId>
       <artifactId>elemental2-dom</artifactId>
     </dependency>

--- a/errai-common/src/main/java/org/jboss/errai/common/client/dom/elemental2/Elemental2DomUtil.java
+++ b/errai-common/src/main/java/org/jboss/errai/common/client/dom/elemental2/Elemental2DomUtil.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.common.client.dom.elemental2;
+
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.Widget;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.Node;
+import jsinterop.base.Js;
+
+/**
+ * Provides utility methods for interacting with the DOM.
+ * @author Guilherme Carreiro <ggomes@redhat.com>
+ */
+public class Elemental2DomUtil {
+
+  /**
+   * Detaches all element children from a node.
+   * @param node Must not be null.
+   * @return True iff any element children were detached by this call.
+   */
+  public boolean removeAllElementChildren(final Node node) {
+
+    final boolean hadChildren = node.lastChild != null;
+
+    while (node.lastChild != null) {
+      node.removeChild(node.lastChild);
+    }
+
+    return hadChildren;
+  }
+
+  /**
+   * Appends the underlying {@link HTMLElement} of a {@link Widget} to another {@link HTMLElement},
+   * in a way that does not break GWT Widget events.
+   * @param parent The parent element that is appended to. Must not be null.
+   * @param child The child Widget, whose underlying HTML element will be
+   * appended to the parent. Must not be null.
+   */
+  public void appendWidgetToElement(final HTMLElement parent, final Widget child) {
+
+    if (child.isAttached()) {
+      child.removeFromParent();
+    }
+
+    RootPanel.detachOnWindowClose(child);
+
+    HTMLElement newChild = asHTMLElement(child.getElement());
+    parent.appendChild(newChild);
+
+    onAttach(child);
+  }
+
+  /**
+   * Converts from {@link com.google.gwt.dom.client.Element} to {@link HTMLElement}.
+   * @param gwtElement The deprecated GWT Element
+   * @return The GWT Elemental2 HTMLElement
+   */
+  public HTMLElement asHTMLElement(final com.google.gwt.dom.client.Element gwtElement) {
+    return Js.cast(gwtElement);
+  }
+
+  /**
+   * Converts from {@link org.jboss.errai.common.client.dom.HTMLElement} to {@link HTMLElement}.
+   * @param htmlElement The deprecated Errai HTMLElement
+   * @return The GWT Elemental2 HTMLElement
+   */
+  public HTMLElement asHTMLElement(final org.jboss.errai.common.client.dom.HTMLElement htmlElement) {
+    return Js.cast(htmlElement);
+  }
+
+  native void onAttach(Widget w)/*-{
+    w.@com.google.gwt.user.client.ui.Widget::onAttach()();
+  }-*/;
+}

--- a/errai-common/src/test/java/org/jboss/errai/common/client/dom/elemental2/Elemental2DomUtilTest.java
+++ b/errai-common/src/test/java/org/jboss/errai/common/client/dom/elemental2/Elemental2DomUtilTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.common.client.dom.elemental2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gwt.junit.GWTMockUtilities;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.Widget;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.Node;
+import jsinterop.base.Js;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+/**
+ * Testing Elemental2DomUtil API.
+ * @author Guilherme Carreiro <ggomes@redhat.com>
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Elemental2DomUtil.class, RootPanel.class, Js.class })
+public class Elemental2DomUtilTest {
+
+  private Elemental2DomUtil elemental2DomUtil;
+
+  @BeforeClass
+  public static void setupPreferences() {
+    // Prevent runtime GWT.create() error at 'content = new SimplePanel()'
+    GWTMockUtilities.disarm();
+  }
+
+  @Before
+  public void setup() {
+    elemental2DomUtil = spy(new Elemental2DomUtil() {
+
+      void onAttach(Widget w) {
+        // fake native
+      }
+    });
+  }
+
+  @Test
+  public void testRemoveAllElementChildrenWhenNodeDoesNotHaveAnyChildren() {
+
+    final Node node = Mockito.spy(makeNode());
+
+    final boolean hadChildren = elemental2DomUtil.removeAllElementChildren(node);
+
+    Mockito.verify(node, Mockito.never()).removeChild(any());
+
+    assertFalse(hadChildren);
+  }
+
+  @Test
+  public void testRemoveAllElementChildrenWhenNodeHasChildren() {
+
+    final Node child1 = mock(Node.class);
+    final Node child2 = mock(Node.class);
+    final Node node = Mockito.spy(makeNode(child1, child2));
+
+    final boolean hadChildren = elemental2DomUtil.removeAllElementChildren(node);
+
+    Mockito.verify(node).removeChild(child1);
+    Mockito.verify(node).removeChild(child2);
+
+    assertTrue(hadChildren);
+  }
+
+  @Test
+  public void testAppendWidgetToElementWhenChildIsAttached() throws Exception {
+
+    final HTMLElement parent = mock(HTMLElement.class);
+    final HTMLElement widgetElement = mock(HTMLElement.class);
+    final Widget child = mock(Widget.class);
+    final Element element = mock(Element.class);
+
+    doReturn(true).when(child).isAttached();
+    doReturn(element).when(child).getElement();
+    doReturn(widgetElement).when(elemental2DomUtil).asHTMLElement(element);
+
+    mockRootPanel();
+
+    elemental2DomUtil.appendWidgetToElement(parent, child);
+
+    verify(child).removeFromParent();
+    verify(parent).appendChild(widgetElement);
+    verify(elemental2DomUtil).onAttach(child);
+
+    verifyStatic();
+    RootPanel.detachOnWindowClose(child);
+  }
+
+  @Test
+  public void testAppendWidgetToElementWhenChildIsNotAttached() throws Exception {
+
+    final HTMLElement parent = mock(HTMLElement.class);
+    final HTMLElement widgetElement = mock(HTMLElement.class);
+    final Widget child = mock(Widget.class);
+    final Element element = mock(Element.class);
+
+    doReturn(false).when(child).isAttached();
+    doReturn(element).when(child).getElement();
+    doReturn(widgetElement).when(elemental2DomUtil).asHTMLElement(element);
+
+    mockRootPanel();
+
+    elemental2DomUtil.appendWidgetToElement(parent, child);
+
+    verify(child, never()).removeFromParent();
+    verify(parent).appendChild(widgetElement);
+    verify(elemental2DomUtil).onAttach(child);
+
+    verifyStatic();
+    RootPanel.detachOnWindowClose(child);
+  }
+
+  @Test
+  public void testAsHTMLElementForGWTElement() throws Exception {
+
+    final com.google.gwt.dom.client.Element gwtElement = mock(com.google.gwt.dom.client.Element.class);
+    final HTMLElement expectedElement = mock(HTMLElement.class);
+
+    mockJsCast(expectedElement, gwtElement);
+
+    final HTMLElement actualElement = elemental2DomUtil.asHTMLElement(gwtElement);
+
+    assertSame(expectedElement, actualElement);
+  }
+
+  @Test
+  public void testAsHTMLElementForErraiHTMLElement() throws Exception {
+
+    final org.jboss.errai.common.client.dom.HTMLElement htmlElement = mock(
+        org.jboss.errai.common.client.dom.HTMLElement.class);
+    final HTMLElement expectedElement = mock(HTMLElement.class);
+
+    mockJsCast(expectedElement, htmlElement);
+
+    final HTMLElement actualElement = elemental2DomUtil.asHTMLElement(htmlElement);
+
+    assertSame(expectedElement, actualElement);
+  }
+
+  private void mockJsCast(final HTMLElement htmlElement, final Object obj) {
+    PowerMockito.spy(Js.class);
+    PowerMockito.doReturn(htmlElement).when(Js.class);
+    Js.cast(obj);
+  }
+
+  private void mockRootPanel() {
+    PowerMockito.mockStatic(RootPanel.class);
+  }
+
+  private Node makeNode(final Node... nodes) {
+
+    final List<Node> nodeList = asArrayList(nodes);
+
+    return new Node() {
+      {
+        lastChild = last(nodeList);
+      }
+
+      public Node removeChild(final Node oldChild) {
+
+        nodeList.remove(oldChild);
+        lastChild = last(nodeList);
+
+        return oldChild;
+      }
+    };
+  }
+
+  private Node last(final List<Node> nodeList) {
+    return nodeList.isEmpty() ? null : nodeList.get(nodeList.size() - 1);
+  }
+
+  private ArrayList<Node> asArrayList(final Node[] nodes) {
+
+    final List<Node> nodeList = Arrays.asList(nodes);
+
+    return new ArrayList<>(nodeList);
+  }
+}


### PR DESCRIPTION
Regarding the `Elemental2DomUtil`, it's an Elemental2 approach for the deprecated `DOMUtil` (https://github.com/errai/errai/blob/master/errai-common/src/main/java/org/jboss/errai/common/client/dom/DOMUtil.java).

Regarding the `errai-internal-bom/pom.xml`, the `elemental2-dom` artifact is being added to avoid classes referenced via transitive dependencies. Since we're deprecating Errai elements in favor of Elementa2, we should make them available `errai-internal-bom/pom.xml`.
