### PR TITLE
Fix issues where deferred messages error handling would be ignored.

### DIFF
--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/framework/ClientMessageBusImpl.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/framework/ClientMessageBusImpl.java
@@ -948,25 +948,44 @@ public class ClientMessageBusImpl implements ClientMessageBus {
     final List<Message> highPriority = new ArrayList<>();
     for (final Message message : new ArrayList<>(deferredMessages)) {
       if (message.hasPart(MessageParts.PriorityProcessing)) {
-        if (remotes.containsKey(message.getSubject()))
+        if (remotes.containsKey(message.getSubject())) {
           highPriority.add(message);
-        deferredMessages.remove(message);
+          deferredMessages.remove(message);
+        }
       }
     }
 
     final List<Message> lowPriority = new ArrayList<>();
-    do {
+    for(Message m : deferredMessages) {
       for (final Message message : new ArrayList<>(deferredMessages)) {
-        if (remotes.containsKey(message.getSubject()))
+        if (remotes.containsKey(message.getSubject())) {
           lowPriority.add(message);
-        deferredMessages.remove(message);
+          deferredMessages.remove(message);
+        }
       }
     }
-    while (!deferredMessages.isEmpty());
 
-    transportHandler.transmit(highPriority);
-    transportHandler.transmit(lowPriority);
-    deferredMessages.clear();
+    try {
+      transportHandler.transmit(highPriority);
+      transportHandler.transmit(lowPriority);
+
+      for (final Message message : deferredMessages) {
+        String subject = message.getSubject();
+        if (!localSubscriptions.containsKey(subject) ||
+            !subscriptions.containsKey(subject) ||
+            !shadowSubscriptions.containsKey(subject)) {
+          try {
+            throw new NoSubscribersToDeliverTo(subject);
+          } catch (NoSubscribersToDeliverTo ex) {
+            if (message.getErrorCallback() != null) {
+              message.getErrorCallback().error(message, ex);
+            }
+          }
+        }
+      }
+    } finally {
+      deferredMessages.clear();
+    }
   }
 
   public boolean handleTransportError(final BusTransportError transportError) {

--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/framework/ClientMessageBusImpl.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/framework/ClientMessageBusImpl.java
@@ -956,12 +956,10 @@ public class ClientMessageBusImpl implements ClientMessageBus {
     }
 
     final List<Message> lowPriority = new ArrayList<>();
-    for(Message m : deferredMessages) {
-      for (final Message message : new ArrayList<>(deferredMessages)) {
-        if (remotes.containsKey(message.getSubject())) {
-          lowPriority.add(message);
-          deferredMessages.remove(message);
-        }
+    for (final Message message : new ArrayList<>(deferredMessages)) {
+      if (remotes.containsKey(message.getSubject())) {
+        lowPriority.add(message);
+        deferredMessages.remove(message);
       }
     }
 
@@ -971,9 +969,9 @@ public class ClientMessageBusImpl implements ClientMessageBus {
 
       for (final Message message : deferredMessages) {
         String subject = message.getSubject();
-        if (!localSubscriptions.containsKey(subject) ||
-            !subscriptions.containsKey(subject) ||
-            !shadowSubscriptions.containsKey(subject)) {
+        if (!(localSubscriptions.containsKey(subject) ||
+             subscriptions.containsKey(subject) ||
+             shadowSubscriptions.containsKey(subject))) {
           try {
             throw new NoSubscribersToDeliverTo(subject);
           } catch (NoSubscribersToDeliverTo ex) {

--- a/errai-bus/src/test/java/org/jboss/errai/bus/client/tests/ServiceAnnotationTests.java
+++ b/errai-bus/src/test/java/org/jboss/errai/bus/client/tests/ServiceAnnotationTests.java
@@ -18,6 +18,7 @@ package org.jboss.errai.bus.client.tests;
 
 import org.jboss.errai.bus.client.ErraiBus;
 import org.jboss.errai.bus.client.api.base.MessageBuilder;
+import org.jboss.errai.bus.client.api.base.NoSubscribersToDeliverTo;
 import org.jboss.errai.bus.client.api.builder.MessageBuildParms;
 import org.jboss.errai.bus.client.api.builder.MessageBuildSendableWithReply;
 import org.jboss.errai.bus.client.api.messaging.Message;
@@ -28,6 +29,7 @@ import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.protocols.MessageParts;
 
 import com.google.gwt.user.client.Timer;
+import org.junit.Assert;
 
 /**
  * Test that annotated services (types or methods) are properly scanned and subscribed by
@@ -193,6 +195,7 @@ public class ServiceAnnotationTests extends AbstractErraiTest {
             .errorsHandledBy(new ErrorCallback<Message>() {
               @Override
               public boolean error(Message message, Throwable throwable) {
+                Assert.assertTrue(throwable instanceof NoSubscribersToDeliverTo);
                 finishTest();
                 return false;
               }
@@ -204,7 +207,7 @@ public class ServiceAnnotationTests extends AbstractErraiTest {
       public void run() {
         if (System.currentTimeMillis() - start > TIMEOUT && !received) {
           cancel();
-          finishTest();
+          fail("No response received after " + (System.currentTimeMillis() - start) + " ms");
         }
         else if (received) {
           cancel();

--- a/errai-bus/src/test/java/org/jboss/errai/bus/client/tests/ServiceAnnotationTests.java
+++ b/errai-bus/src/test/java/org/jboss/errai/bus/client/tests/ServiceAnnotationTests.java
@@ -195,7 +195,7 @@ public class ServiceAnnotationTests extends AbstractErraiTest {
             .errorsHandledBy(new ErrorCallback<Message>() {
               @Override
               public boolean error(Message message, Throwable throwable) {
-                Assert.assertTrue(throwable instanceof NoSubscribersToDeliverTo);
+                assertTrue(throwable instanceof NoSubscribersToDeliverTo);
                 finishTest();
                 return false;
               }

--- a/errai-bus/src/test/java/org/jboss/errai/bus/client/tests/ServiceAnnotationTests.java
+++ b/errai-bus/src/test/java/org/jboss/errai/bus/client/tests/ServiceAnnotationTests.java
@@ -193,7 +193,8 @@ public class ServiceAnnotationTests extends AbstractErraiTest {
             .errorsHandledBy(new ErrorCallback<Message>() {
               @Override
               public boolean error(Message message, Throwable throwable) {
-                throw new RuntimeException("error occurred with message: " + throwable.getMessage(), throwable);
+                finishTest();
+                return false;
               }
             }).sendNowWith(bus);
 

--- a/errai-cdi/errai-cdi-server/src/test/java/org/jboss/errai/cdi/event/client/test/CDIServiceAnnotationTests.java
+++ b/errai-cdi/errai-cdi-server/src/test/java/org/jboss/errai/cdi/event/client/test/CDIServiceAnnotationTests.java
@@ -192,7 +192,8 @@ public class CDIServiceAnnotationTests extends AbstractErraiTest {
             .errorsHandledBy(new ErrorCallback<Message>() {
               @Override
               public boolean error(Message message, Throwable throwable) {
-                throw new RuntimeException("error occurred with message: " + throwable.getMessage(), throwable);
+                finishTest();
+                return false;
               }
             }).sendNowWith(bus);
 

--- a/errai-cdi/errai-cdi-server/src/test/java/org/jboss/errai/cdi/event/client/test/CDIServiceAnnotationTests.java
+++ b/errai-cdi/errai-cdi-server/src/test/java/org/jboss/errai/cdi/event/client/test/CDIServiceAnnotationTests.java
@@ -18,6 +18,7 @@ package org.jboss.errai.cdi.event.client.test;
 
 import org.jboss.errai.bus.client.ErraiBus;
 import org.jboss.errai.bus.client.api.base.MessageBuilder;
+import org.jboss.errai.bus.client.api.base.NoSubscribersToDeliverTo;
 import org.jboss.errai.bus.client.api.builder.MessageBuildParms;
 import org.jboss.errai.bus.client.api.builder.MessageBuildSendableWithReply;
 import org.jboss.errai.bus.client.api.messaging.Message;
@@ -28,6 +29,7 @@ import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.protocols.MessageParts;
 
 import com.google.gwt.user.client.Timer;
+import org.junit.Assert;
 
 /**
  * Test that annotated services (types or methods) are properly scanned and subscribed by
@@ -192,6 +194,7 @@ public class CDIServiceAnnotationTests extends AbstractErraiTest {
             .errorsHandledBy(new ErrorCallback<Message>() {
               @Override
               public boolean error(Message message, Throwable throwable) {
+                Assert.assertTrue(throwable instanceof NoSubscribersToDeliverTo);
                 finishTest();
                 return false;
               }
@@ -203,7 +206,7 @@ public class CDIServiceAnnotationTests extends AbstractErraiTest {
       public void run() {
         if (System.currentTimeMillis() - start > TIMEOUT && !received) {
           cancel();
-          finishTest();
+          fail("No response received after " + (System.currentTimeMillis() - start) + " ms");
         }
         else if (received) {
           cancel();

--- a/errai-cdi/errai-cdi-server/src/test/java/org/jboss/errai/cdi/event/client/test/CDIServiceAnnotationTests.java
+++ b/errai-cdi/errai-cdi-server/src/test/java/org/jboss/errai/cdi/event/client/test/CDIServiceAnnotationTests.java
@@ -194,7 +194,7 @@ public class CDIServiceAnnotationTests extends AbstractErraiTest {
             .errorsHandledBy(new ErrorCallback<Message>() {
               @Override
               public boolean error(Message message, Throwable throwable) {
-                Assert.assertTrue(throwable instanceof NoSubscribersToDeliverTo);
+                assertTrue(throwable instanceof NoSubscribersToDeliverTo);
                 finishTest();
                 return false;
               }


### PR DESCRIPTION
This accounts for times where messages are ignored, rather than sink them, we should be throwing a NoSubscribersToDeliverTo exception.

Let me know if there is a more acceptable way to handle this.
