### PR TITLE
Support custom security exception handling

### DIFF
--- a/errai-cdi/errai-cdi-client/src/main/java/org/jboss/errai/enterprise/client/cdi/InstanceProvider.java
+++ b/errai-cdi/errai-cdi-client/src/main/java/org/jboss/errai/enterprise/client/cdi/InstanceProvider.java
@@ -89,7 +89,7 @@ public class InstanceProvider implements ContextualTypeProvider<Instance> {
     @Override
     public Iterator<T> iterator() {
       final Collection<SyncBeanDef<T>> beanDefs = IOC.getBeanManager().lookupBeans( type, qualifiers );
-      if(beanDefs==null){
+      if (beanDefs==null){
         return Collections.<T>emptyList().iterator();
       }
       return new InstanceImplIterator(beanDefs);

--- a/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
+++ b/errai-cdi/jboss/src/main/java/org/jboss/errai/cdi/server/gwt/EmbeddedWildFlyLauncher.java
@@ -158,11 +158,11 @@ public class EmbeddedWildFlyLauncher extends ServletContainerLauncher {
 
         for (final String currentLine : lines) {
           String trimmed = currentLine.trim();
-          if(trimmed.startsWith(ERRAI_PROPERTIES_HINT_START.trim())) {
+          if (trimmed.startsWith(ERRAI_PROPERTIES_HINT_START.trim())) {
             isErraiContent = true;
-          } else if(trimmed.startsWith(ERRAI_PROPERTIES_HINT_END.trim())) {
+          } else if (trimmed.startsWith(ERRAI_PROPERTIES_HINT_END.trim())) {
             isErraiContent = false;
-          } else if(handleRealmToken && trimmed.startsWith("#") && trimmed.contains("$REALM_NAME=")) {
+          } else if (handleRealmToken && trimmed.startsWith("#") && trimmed.contains("$REALM_NAME=")) {
             realmToken = currentLine;
           } else if (!isErraiContent) {
             result.append(currentLine).append("\n");

--- a/errai-demos/errai-jpa-demo-grocery-list/src/main/java/org/jboss/errai/demo/grocery/client/local/ItemForm.java
+++ b/errai-demos/errai-jpa-demo-grocery-list/src/main/java/org/jboss/errai/demo/grocery/client/local/ItemForm.java
@@ -53,7 +53,7 @@ public class ItemForm extends Form {
   // TODO (after ERRAI-366): make this method package-private
   @EventHandler("saveButton")
   public void onSaveButtonClicked(ClickEvent event) {
-    if(!isValidName())
+    if (!isValidName())
       return;
    
     String departmentText = department.getText();

--- a/errai-marshalling/src/main/java/org/jboss/errai/marshalling/rebind/api/impl/defaultjava/DefaultJavaMappingStrategy.java
+++ b/errai-marshalling/src/main/java/org/jboss/errai/marshalling/rebind/api/impl/defaultjava/DefaultJavaMappingStrategy.java
@@ -759,7 +759,7 @@ public class DefaultJavaMappingStrategy implements MappingStrategy {
   private boolean containsInnerClass(ClassStructureBuilder<?> classStructureBuilder, BuildMetaClass inner) {
     MetaClass[] innerClasses = classStructureBuilder.getClassDefinition().getDeclaredClasses();
     for (MetaClass innerClass : innerClasses) {
-      if(innerClass.getFullyQualifiedName().equals(inner.getFullyQualifiedName())) {
+      if (innerClass.getFullyQualifiedName().equals(inner.getFullyQualifiedName())) {
         return true;
       }
     }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultNavigationErrorHandler.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/DefaultNavigationErrorHandler.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
  * Implements default error handling behavior for page navigation.
  *
  * @author Divya Dadlani <ddadlani@redhat.com>
- *
  */
 public class DefaultNavigationErrorHandler implements PageNavigationErrorHandler {
 
@@ -40,8 +39,7 @@ public class DefaultNavigationErrorHandler implements PageNavigationErrorHandler
   public void handleInvalidPageNameError(Exception exception, String pageName) {
     if (pageName.equals("")) {
       throw new Error("Failed to initialize Default Page", exception);
-    }
-    else {
+    } else {
       logger.warn("Got invalid page name \"" + pageName + "\". Redirecting to default page.", exception);
       navigation.goTo("");
     }
@@ -51,8 +49,7 @@ public class DefaultNavigationErrorHandler implements PageNavigationErrorHandler
   public void handleError(Exception exception, Class<? extends UniquePageRole> pageRole) {
     if (pageRole.equals(DefaultPage.class)) {
       throw new Error("Failed to initialize Default Page", exception);
-    }
-    else {
+    } else {
       logger.error("Got invalid page role \"" + pageRole + "\". Redirecting to default page.", exception);
       navigation.goTo("");
     }
@@ -60,13 +57,11 @@ public class DefaultNavigationErrorHandler implements PageNavigationErrorHandler
 
   @Override
   public void handleInvalidURLError(Exception exception, String urlPath) {
-    if(urlPath.equals("")) {
+    if (urlPath.equals("")) {
       throw new Error("Failed to initialize Default Page", exception);
-    }
-    else {
+    } else {
       logger.warn("Got invalid URL \"" + urlPath + "\". Redirecting to default page.", exception);
       navigation.goTo("");
     }
   }
-
 }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
@@ -647,6 +647,13 @@ public class Navigation {
       return instance.@com.google.gwt.user.client.ui.Composite::widget;
   }-*/;
 
+  /**
+   * Are we in the navigation process right now.
+   */
+  public boolean isNavigating() {
+    return locked;
+  }
+
   public void setContentDelegation(ContentDelegation contentDelegation) {
     this.contentDelegation = contentDelegation;
   }

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/api/NavigationControl.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/api/NavigationControl.java
@@ -75,8 +75,8 @@ public class NavigationControl {
    * @param state Pages state map.
    */
   public <C> void redirect(final Class<C> toPage, final Multimap<String, String> state) {
-    if(!hasRun) {
-      if(interrupt != null) {
+    if (!hasRun) {
+      if (interrupt != null) {
         interrupt.run();
       }
       navigation.goTo(toPage, state);

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/pushstate/HistoryImplPushState.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/pushstate/HistoryImplPushState.java
@@ -75,7 +75,7 @@ public class HistoryImplPushState implements HasValueChangeHandlers<String> {
       newPushStateToken = "/" + newPushStateToken;
     }
     
-    if(replace){
+    if (replace){
       replaceState(newPushStateToken);
       if (LogConfiguration.loggingIsEnabled()) {
         LOG.fine("Replaced '" + newPushStateToken + "' (" + historyToken + ")");

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
@@ -163,7 +163,7 @@ public class NavigationGraphGenerator extends AbstractAsyncGenerator {
         if (annotatedPageRoles.contains(DefaultPage.class)) {
           // need to assign the page impl to a variable and add it to the map twice
           URLPattern pattern = URLPatternMatcher.generatePattern(annotation.path());
-          if(pattern.getParamList().size() > 0) {
+          if (pattern.getParamList().size() > 0) {
             throw new GenerationException("Default Page must not contain any path parameters.");
           }
           ctor.append(Stmt.declareFinalVariable("defaultPage", PageNode.class, pageImplStmt));
@@ -457,7 +457,7 @@ public class NavigationGraphGenerator extends AbstractAsyncGenerator {
       PrivateAccessUtil.addPrivateAccessStubs("jsni", pageImplBuilder, metaMethod, new Modifier[] {});
 
       if (optionalParams != null) {
-        if(realParamLength <= optionalParams.length) {
+        if (realParamLength <= optionalParams.length) {
           for (int i = 1; i < paramValues.length; i++) {
             Parameter param = optionalParams[i - 1];
             MetaParameter realParam = metaMethod.getParameters()[i - 1];

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/api/SecurityContext.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/api/SecurityContext.java
@@ -16,6 +16,7 @@
 
 package org.jboss.errai.security.client.local.api;
 
+import com.google.common.collect.Multimap;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.jboss.errai.security.shared.service.AuthenticationService;
 import org.jboss.errai.ui.nav.client.local.DefaultPage;
@@ -24,8 +25,6 @@ import org.jboss.errai.ui.nav.client.local.Page;
 import org.jboss.errai.ui.nav.client.local.PageState;
 import org.jboss.errai.ui.nav.client.local.api.LoginPage;
 import org.jboss.errai.ui.nav.client.local.api.SecurityError;
-
-import com.google.common.collect.Multimap;
 
 /**
  * Caches information regarding security events and the current user (i.e. which

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/callback/DefaultBusSecurityErrorCallback.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/callback/DefaultBusSecurityErrorCallback.java
@@ -16,17 +16,16 @@
 
 package org.jboss.errai.security.client.local.callback;
 
-import javax.inject.Inject;
-
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.api.UncaughtExceptionHandler;
-import org.jboss.errai.security.client.local.api.SecurityContext;
+import org.jboss.errai.security.client.local.handler.SecurityExceptionHandler;
 import org.jboss.errai.security.shared.exception.SecurityException;
 import org.jboss.errai.security.shared.exception.UnauthenticatedException;
 import org.jboss.errai.security.shared.exception.UnauthorizedException;
 import org.jboss.errai.ui.nav.client.local.api.LoginPage;
-import org.jboss.errai.ui.nav.client.local.api.MissingPageRoleException;
 import org.jboss.errai.ui.nav.client.local.api.SecurityError;
+
+import javax.inject.Inject;
 
 /**
  * Catches {@link SecurityException SecurityExceptions}. If an
@@ -39,33 +38,19 @@ import org.jboss.errai.ui.nav.client.local.api.SecurityError;
 @EntryPoint
 public class DefaultBusSecurityErrorCallback {
 
-  private final SecurityContext context;
+  private SecurityExceptionHandler handler;
 
   // For proxying
   public DefaultBusSecurityErrorCallback() {
-    context = null;
   }
 
   @Inject
-  public DefaultBusSecurityErrorCallback(final SecurityContext context) {
-    this.context = context;
+  public DefaultBusSecurityErrorCallback(final SecurityExceptionHandler handler) {
+    this.handler = handler;
   }
 
   @UncaughtExceptionHandler
-  public void handleError(final Throwable throwable) {
-    try {
-      if (throwable instanceof UnauthenticatedException) {
-        context.redirectToLoginPage();
-      }
-      else if (throwable instanceof UnauthorizedException) {
-        context.redirectToSecurityErrorPage();
-      }
-    }
-    catch (MissingPageRoleException ex) {
-      throw new RuntimeException(
-              "Could not redirect the user to the appropriate page because no page with that role was found.", ex);
-    }
-
+  public void handleError(final Throwable caught) {
+    handler.handleException(caught);
   }
-
 }

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/callback/DefaultRestSecurityErrorCallback.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/callback/DefaultRestSecurityErrorCallback.java
@@ -16,18 +16,18 @@
 
 package org.jboss.errai.security.client.local.callback;
 
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-
+import com.google.gwt.http.client.Request;
 import org.jboss.errai.enterprise.client.jaxrs.api.RestErrorCallback;
 import org.jboss.errai.security.client.local.api.SecurityContext;
+import org.jboss.errai.security.client.local.handler.SecurityExceptionHandler;
 import org.jboss.errai.security.shared.exception.UnauthenticatedException;
 import org.jboss.errai.security.shared.exception.UnauthorizedException;
 import org.jboss.errai.ui.nav.client.local.api.LoginPage;
 import org.jboss.errai.ui.nav.client.local.api.MissingPageRoleException;
 import org.jboss.errai.ui.nav.client.local.api.SecurityError;
 
-import com.google.gwt.http.client.Request;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
 /**
  * A {@link RestErrorCallback} that catches {@link UnauthenticatedException
@@ -55,6 +55,8 @@ public class DefaultRestSecurityErrorCallback implements RestErrorCallback {
 
   private final SecurityContext context;
 
+  private final SecurityExceptionHandler handler;
+
   /**
    * Create a {@link DefaultRestSecurityErrorCallback} wrapping a given
    * {@link RestErrorCallback}.
@@ -62,15 +64,18 @@ public class DefaultRestSecurityErrorCallback implements RestErrorCallback {
    * @param wrapped
    *          The wrapped callback (should never be {@code null}, that will be
    *          invoked first when
-   *          {@link RestErrorCallback#error(Request, Throwable)} is called. If
+   *          {@link RestErrorCallback#error(Object, Throwable)} is called. If
    *          the error method on the {@code wrapped} returns {@code false}, the
    *          whole callback returns {@code false} immediately.
    * @param context
    *          The {@link SecurityContext}.
+   * @param handler
+   *          The exception handler.
    */
-  public DefaultRestSecurityErrorCallback(final RestErrorCallback wrapped, final SecurityContext context) {
+  public DefaultRestSecurityErrorCallback(final RestErrorCallback wrapped, final SecurityContext context, SecurityExceptionHandler handler) {
     this.context = context;
     this.wrapped = wrapped;
+    this.handler = handler;
   }
 
   /**
@@ -78,38 +83,23 @@ public class DefaultRestSecurityErrorCallback implements RestErrorCallback {
    * 
    * @param context
    *          The {@link SecurityContext}.
+   * @param handler
+   *          The exception handler.
    */
   @Inject
-  public DefaultRestSecurityErrorCallback(final SecurityContext context) {
-    this(defaultWrapped, context);
+  public DefaultRestSecurityErrorCallback(final SecurityContext context, SecurityExceptionHandler handler) {
+    this(defaultWrapped, context, handler);
   }
 
   @Override
-  public boolean error(final Request message, final Throwable throwable) throws MissingPageRoleException {
-    if (wrapped.error(message, throwable)) {
-      try {
-        if (throwable instanceof UnauthenticatedException) {
-          context.redirectToLoginPage();
-        }
-        else if (throwable instanceof UnauthorizedException) {
-          context.redirectToSecurityErrorPage();
-        }
-        else {
-          return true;
-        }
-      }
-      catch (MissingPageRoleException ex) {
-        throw new RuntimeException(
-                "Could not redirect the user to the appropriate page because no page with that role was found.", ex);
-      }
-    }
-
-    return false;
+  @SuppressWarnings("Duplicates")
+  public boolean error(final Request message, final Throwable caught) throws MissingPageRoleException {
+    return wrapped.error(message, caught) && handler.handleException(caught);
   }
 
   /**
    * Set the wrapped callback that will be invoked first when
-   * {@link RestErrorCallback#error(Request, Throwable)} is called. If the error
+   * {@link RestErrorCallback#error(Object, Throwable)} is called. If the error
    * method on the wrapped callback returns {@code false}, the whole callback
    * returns {@code false} immediately.
    * 

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/callback/DefaultRestSecurityErrorCallback.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/callback/DefaultRestSecurityErrorCallback.java
@@ -18,7 +18,6 @@ package org.jboss.errai.security.client.local.callback;
 
 import com.google.gwt.http.client.Request;
 import org.jboss.errai.enterprise.client.jaxrs.api.RestErrorCallback;
-import org.jboss.errai.security.client.local.api.SecurityContext;
 import org.jboss.errai.security.client.local.handler.SecurityExceptionHandler;
 import org.jboss.errai.security.shared.exception.UnauthenticatedException;
 import org.jboss.errai.security.shared.exception.UnauthorizedException;
@@ -53,9 +52,7 @@ public class DefaultRestSecurityErrorCallback implements RestErrorCallback {
 
   private RestErrorCallback wrapped;
 
-  private final SecurityContext context;
-
-  private final SecurityExceptionHandler handler;
+  private SecurityExceptionHandler handler;
 
   /**
    * Create a {@link DefaultRestSecurityErrorCallback} wrapping a given
@@ -67,28 +64,23 @@ public class DefaultRestSecurityErrorCallback implements RestErrorCallback {
    *          {@link RestErrorCallback#error(Object, Throwable)} is called. If
    *          the error method on the {@code wrapped} returns {@code false}, the
    *          whole callback returns {@code false} immediately.
-   * @param context
-   *          The {@link SecurityContext}.
    * @param handler
    *          The exception handler.
    */
-  public DefaultRestSecurityErrorCallback(final RestErrorCallback wrapped, final SecurityContext context, SecurityExceptionHandler handler) {
-    this.context = context;
+  public DefaultRestSecurityErrorCallback(final RestErrorCallback wrapped, final SecurityExceptionHandler handler) {
     this.wrapped = wrapped;
     this.handler = handler;
   }
 
   /**
    * Create a {@link DefaultRestSecurityErrorCallback}.
-   * 
-   * @param context
-   *          The {@link SecurityContext}.
+   *
    * @param handler
    *          The exception handler.
    */
   @Inject
-  public DefaultRestSecurityErrorCallback(final SecurityContext context, SecurityExceptionHandler handler) {
-    this(defaultWrapped, context, handler);
+  public DefaultRestSecurityErrorCallback(SecurityExceptionHandler handler) {
+    this(defaultWrapped, handler);
   }
 
   @Override

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/context/SecurityContextImpl.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/context/SecurityContextImpl.java
@@ -16,10 +16,9 @@
 
 package org.jboss.errai.security.client.local.context;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.event.Event;
-import javax.inject.Inject;
-
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import org.jboss.errai.bus.client.ErraiBus;
 import org.jboss.errai.bus.client.api.ClientMessageBus;
 import org.jboss.errai.bus.client.framework.BusState;
@@ -49,9 +48,9 @@ import org.jboss.errai.ui.nav.rebind.NavigationGraphGenerator;
 import org.jboss.errai.ui.shared.api.style.StyleBindingsRegistry;
 import org.slf4j.Logger;
 
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
 
 /**
  * @author Max Barkley <mbarkley@redhat.com>
@@ -266,5 +265,4 @@ public class SecurityContextImpl implements SecurityContext {
   public boolean isUserCacheValid() {
     return userCache.isValid();
   }
-
 }

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/handler/DefaultSecurityExceptionHandler.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/handler/DefaultSecurityExceptionHandler.java
@@ -1,0 +1,44 @@
+package org.jboss.errai.security.client.local.handler;
+
+import org.jboss.errai.security.client.local.api.SecurityContext;
+import org.jboss.errai.security.shared.exception.UnauthenticatedException;
+import org.jboss.errai.security.shared.exception.UnauthorizedException;
+import org.jboss.errai.ui.nav.client.local.api.MissingPageRoleException;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Default {@link SecurityExceptionHandler}.
+ */
+@Singleton
+public class DefaultSecurityExceptionHandler implements SecurityExceptionHandler {
+
+  protected final SecurityContext context;
+
+  // For proxying
+  public DefaultSecurityExceptionHandler() {
+    context = null;
+  }
+
+  @Inject
+  public DefaultSecurityExceptionHandler(SecurityContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public boolean handleException(Throwable throwable) {
+    try {
+      if (throwable instanceof UnauthenticatedException) {
+        context.redirectToLoginPage();
+      } else if (throwable instanceof UnauthorizedException) {
+        context.redirectToSecurityErrorPage();
+      }
+    }
+    catch (MissingPageRoleException ex) {
+      throw new RuntimeException(
+          "Could not redirect the user to the appropriate page because no page with that role was found.", ex);
+    }
+    return true;
+  }
+}

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/handler/DefaultSecurityExceptionHandler.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/handler/DefaultSecurityExceptionHandler.java
@@ -14,11 +14,10 @@ import javax.inject.Singleton;
 @Singleton
 public class DefaultSecurityExceptionHandler implements SecurityExceptionHandler {
 
-  protected final SecurityContext context;
+  protected SecurityContext context;
 
   // For proxying
   public DefaultSecurityExceptionHandler() {
-    context = null;
   }
 
   @Inject

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/handler/SecurityExceptionHandler.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/handler/SecurityExceptionHandler.java
@@ -1,0 +1,17 @@
+package org.jboss.errai.security.client.local.handler;
+
+import org.jboss.errai.enterprise.client.jaxrs.api.RestErrorCallback;
+
+/**
+ * Security handler for handling a {@link org.jboss.errai.security.shared.exception.SecurityException}.
+ */
+public interface SecurityExceptionHandler {
+
+    /**
+     * Handling of a {@link SecurityException}.
+     *
+     * @param caught the exception to handle.
+     * @return true to continue with default error handling (currently only applicable to {@link RestErrorCallback}.
+     */
+    boolean handleException(Throwable caught);
+}

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/handler/SecurityExceptionHandler.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/handler/SecurityExceptionHandler.java
@@ -7,11 +7,12 @@ import org.jboss.errai.enterprise.client.jaxrs.api.RestErrorCallback;
  */
 public interface SecurityExceptionHandler {
 
-    /**
-     * Handling of a {@link SecurityException}.
-     *
-     * @param caught the exception to handle.
-     * @return true to continue with default error handling (currently only applicable to {@link RestErrorCallback}.
-     */
-    boolean handleException(Throwable caught);
+  /**
+   * Handling of a {@link SecurityException}.
+   *
+   * @param caught the exception to handle.
+   * @return true to continue with default error handling (currently only applicable to {@link RestErrorCallback}.
+   */
+  boolean handleException(Throwable caught);
+
 }

--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/interceptors/ClientSecurityRoleInterceptor.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/interceptors/ClientSecurityRoleInterceptor.java
@@ -16,12 +16,6 @@
 
 package org.jboss.errai.security.client.local.interceptors;
 
-import java.lang.annotation.Annotation;
-import java.util.Set;
-
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-
 import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.common.client.api.interceptor.FeatureInterceptor;
@@ -35,6 +29,11 @@ import org.jboss.errai.security.shared.exception.UnauthorizedException;
 import org.jboss.errai.security.shared.spi.RequiredRolesExtractor;
 import org.jboss.errai.security.shared.util.AnnotationUtils;
 
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 /**
  * Intercepts RPC calls to resources marked with {@link RestrictedAccess}. This
  * interceptor throws an {@link UnauthenticatedException} if the user is not
@@ -44,10 +43,9 @@ import org.jboss.errai.security.shared.util.AnnotationUtils;
  * @author edewit@redhat.com
  * @author Max Barkley <mbarkley@redhat.com>
  */
-@FeatureInterceptor(RestrictedAccess.class)
 @Dependent
-public class ClientSecurityRoleInterceptor implements
-RemoteCallInterceptor<RemoteCallContext> {
+@FeatureInterceptor(RestrictedAccess.class)
+public class ClientSecurityRoleInterceptor implements RemoteCallInterceptor<RemoteCallContext> {
 
   private final SecurityContext securityContext;
   private final RequiredRolesExtractor roleExtractor;
@@ -67,11 +65,11 @@ RemoteCallInterceptor<RemoteCallContext> {
   @Override
   public void aroundInvoke(final RemoteCallContext callContext) {
     securityCheck(
-            AnnotationUtils.mergeRoles(
-                    roleExtractor,
-                    getRestrictedAccessAnnotation(callContext.getTypeAnnotations()),
-                    getRestrictedAccessAnnotation(callContext.getAnnotations())),
-                    callContext);
+        AnnotationUtils.mergeRoles(
+            roleExtractor,
+            getRestrictedAccessAnnotation(callContext.getTypeAnnotations()),
+            getRestrictedAccessAnnotation(callContext.getAnnotations())),
+        callContext);
   }
 
   private void securityCheck(final Set<Role> requiredRoleNames, final RemoteCallContext callContext) {
@@ -95,16 +93,13 @@ RemoteCallInterceptor<RemoteCallContext> {
               return true;
             }
           });
-        }
-        else {
+        } else {
           throw new UnauthorizedException();
         }
-      }
-      else {
+      } else {
         throw new UnauthenticatedException();
       }
-    }
-    else {
+    } else {
       callContext.proceed();
     }
   }
@@ -117,5 +112,4 @@ RemoteCallInterceptor<RemoteCallContext> {
     }
     return null;
   }
-
 }

--- a/errai-security/errai-security-keycloak/src/main/java/org/jboss/errai/security/keycloak/KeycloakAuthenticationService.java
+++ b/errai-security/errai-security-keycloak/src/main/java/org/jboss/errai/security/keycloak/KeycloakAuthenticationService.java
@@ -235,13 +235,13 @@ public class KeycloakAuthenticationService implements AuthenticationService, Ser
     
     //Add app roles first, if any
     AccessToken.Access access = accessToken.getResourceAccess(accessToken.getIssuedFor());
-    if(access != null && access.getRoles() != null){
+    if (access != null && access.getRoles() != null){
       roleNames.addAll(access.getRoles());
     }
 
     //Add realm roles next, if any
     AccessToken.Access realmAccess = accessToken.getRealmAccess();
-    if(realmAccess != null && realmAccess.getRoles() != null){
+    if (realmAccess != null && realmAccess.getRoles() != null){
       roleNames.addAll(realmAccess.getRoles());
     }
 

--- a/errai-ui/src/main/java/org/jboss/errai/ui/rebind/ioc/element/ElementInjectionBodyGenerator.java
+++ b/errai-ui/src/main/java/org/jboss/errai/ui/rebind/ioc/element/ElementInjectionBodyGenerator.java
@@ -90,7 +90,7 @@ class ElementInjectionBodyGenerator extends AbstractBodyGenerator {
               loadLiteral(property.value())));
     }
 
-    if(!Strings.isNullOrEmpty(classNames)) {
+    if (!Strings.isNullOrEmpty(classNames)) {
       stmts.add(loadVariable(elementVar).invoke("addClassName", loadLiteral(classNames)));
     }
     final String retValVar = "retVal";

--- a/errai-ui/src/main/java/org/jboss/errai/ui/rebind/ioc/element/ElementProviderExtension.java
+++ b/errai-ui/src/main/java/org/jboss/errai/ui/rebind/ioc/element/ElementProviderExtension.java
@@ -204,7 +204,7 @@ public class ElementProviderExtension implements IOCExtensionConfigurator {
   private static String getClassNames(final MetaClass type){
     String result = "";
     final ClassNames classNames = type.getAnnotation(ClassNames.class);
-    if(classNames != null){
+    if (classNames != null){
       result = String.join(" ", classNames.value());
     }
     return result;

--- a/errai-ui/src/main/java/org/jboss/errai/ui/shared/TemplateWidget.java
+++ b/errai-ui/src/main/java/org/jboss/errai/ui/shared/TemplateWidget.java
@@ -57,7 +57,7 @@ public class TemplateWidget extends Panel {
 
   @Override
   public boolean remove(final Widget child) {
-    if(child.getParent() != this)
+    if (child.getParent() != this)
     {
       return false;
     }


### PR DESCRIPTION
This fixes a security issue with ClientSecurityRoleInterceptor if an invalid user cache is found it simply proceeds the call, however we should check if there are required roles, if so, then we should not proceed, but instead throw an UnauthenticatedException. This lead to simply making the call before the user was validated and it would succeed.

Use a SecurityExceptionHandler to define SecurityException handling or stick with the default.

Example of using your own SecurityExceptionHandler:
```java
@Singleton
@Alternative
public class SecurityExceptionHandler extends DefaultSecurityExceptionHandler {

    @Inject
    public SecurityExceptionHandler(SecurityContext context) {
        super(context);
    }

    @Override
    public boolean handleException(Throwable caught) {
        // We will only allow for redirection if we are in the
        // navigation phase.
        return !context.getNavigation().isNavigating() || super.handleException(caught);
    }
}
```

ErraiApp.properties:
```
errai.ioc.enabled.alternatives=xx.yy.zz.MySecurityExceptionHandler
```
