### PR TITLE
Upgrade GWT to 2.8.2

### DIFF
--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -41,7 +41,7 @@
     <guava.version>20.0</guava.version>
     <guice.version>3.0</guice.version>
     <gwt.phonegap.version>3.5.0.1</gwt.phonegap.version>
-    <gwt.version>2.8.1</gwt.version>
+    <gwt.version>2.8.2</gwt.version>
     <!-- TODO test with 2.x version in ip-bom -->
     <hsqldb.version>1.8.0.7</hsqldb.version>
     <javaee.api.version>7.0</javaee.api.version>

--- a/errai-bus/src/test/java/org/jboss/errai/bus/TestCommon.gwt.xml
+++ b/errai-bus/src/test/java/org/jboss/errai/bus/TestCommon.gwt.xml
@@ -22,4 +22,7 @@
     <inherits name="org.jboss.errai.bus.ErraiBus"/>
     
     <source path="common"/>
+
+    <!-- GWT 2.8.2 changed the value (by default) to 'REPORT_IF_NO_HANDLER' which is causing test failures. -->
+    <set-property name="gwt.uncaughtexceptionhandler.windowonerror" value="IGNORE"/>
 </module>

--- a/errai-demos/errai-bus-demo-stock/pom.xml
+++ b/errai-demos/errai-bus-demo-stock/pom.xml
@@ -59,7 +59,7 @@
     <maven.clean.plugin.version>2.4.1</maven.clean.plugin.version>
     <maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
     <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version>
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
   </properties>
 
   <repositories>

--- a/errai-demos/errai-bus-demo-stress-test/pom.xml
+++ b/errai-demos/errai-bus-demo-stress-test/pom.xml
@@ -61,7 +61,7 @@
     <maven.clean.plugin.version>2.4.1</maven.clean.plugin.version>
     <maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
     <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version> 
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
   </properties>
 
   <repositories>

--- a/errai-demos/errai-cdi-demo-mobile/pom.xml
+++ b/errai-demos/errai-cdi-demo-mobile/pom.xml
@@ -62,7 +62,7 @@
     <maven.clean.plugin.version>2.4.1</maven.clean.plugin.version>
     <maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
     <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version>
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
     <jetty.version>9.2.14.v20151106</jetty.version>
     <!-- Dev Mode config properties -->
     <errai.dev.context>${project.artifactId}</errai.dev.context>

--- a/errai-demos/errai-cdi-demo-tagcloud/pom.xml
+++ b/errai-demos/errai-cdi-demo-tagcloud/pom.xml
@@ -60,7 +60,7 @@
     <maven.clean.plugin.version>2.4.1</maven.clean.plugin.version>
     <maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
     <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version>
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
     <jetty.version>9.2.14.v20151106</jetty.version>
     <!-- Dev Mode config properties -->
     <errai.dev.context>${project.artifactId}</errai.dev.context>

--- a/errai-demos/errai-jaxrs-demo-crud/pom.xml
+++ b/errai-demos/errai-jaxrs-demo-crud/pom.xml
@@ -63,7 +63,7 @@
     <maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
     <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>    
     <maven.surefire.plugin.version>2.5</maven.surefire.plugin.version>
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version>
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
     <jetty.version>9.2.14.v20151106</jetty.version>
     <!-- Dev Mode config properties -->
     <errai.dev.context>${project.artifactId}</errai.dev.context>

--- a/errai-demos/errai-jpa-demo-basic/pom.xml
+++ b/errai-demos/errai-jpa-demo-basic/pom.xml
@@ -61,7 +61,7 @@
     <maven.clean.plugin.version>2.4.1</maven.clean.plugin.version>
     <maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
     <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version> 
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version>   
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
     <weld.version>2.3.3.Final</weld.version>
     <jetty.version>9.2.14.v20151106</jetty.version>
     <!-- Dev Mode config properties -->

--- a/errai-demos/errai-jpa-demo-grocery-list/pom.xml
+++ b/errai-demos/errai-jpa-demo-grocery-list/pom.xml
@@ -59,7 +59,7 @@
     <slf4j.version>1.7.10</slf4j.version>
     <cdiapi.version>1.2</cdiapi.version>
     <servletapi.version>1.0.2.Final</servletapi.version>
-    <gwt.maven.version>2.8.1</gwt.maven.version>
+    <gwt.maven.version>2.8.2</gwt.maven.version>
     <maven.compiler.plugin.version>3.2</maven.compiler.plugin.version>
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
     <argLine></argLine>

--- a/errai-demos/errai-jpa-demo-todo-list/pom.xml
+++ b/errai-demos/errai-jpa-demo-todo-list/pom.xml
@@ -55,7 +55,7 @@
     <picketlink.version>2.6.0.Final</picketlink.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.war.plugin.version>2.1.1</maven.war.plugin.version>
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version>
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
     <skipTests>true</skipTests>
     <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>
     <argLine></argLine>

--- a/errai-demos/errai-security-demo/pom.xml
+++ b/errai-demos/errai-security-demo/pom.xml
@@ -61,7 +61,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javaee.version>3.0.1.Final</javaee.version>
     <errai.dev.context>${project.artifactId}</errai.dev.context>
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version>
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
     <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>
   </properties>
 

--- a/errai-demos/errai-ui-demo-i18n/pom.xml
+++ b/errai-demos/errai-ui-demo-i18n/pom.xml
@@ -64,7 +64,7 @@
     <version>${maven.compiler.plugin.version}</version>  
     <jetty.version>6.1.25</jetty.version>
     <jboss-as-maven-plugin.version>7.4.Final</jboss-as-maven-plugin.version>
-    <maven.gwt.plugin.version>2.8.1</maven.gwt.plugin.version>
+    <maven.gwt.plugin.version>2.8.2</maven.gwt.plugin.version>
   </properties>
 
   <repositories>

--- a/errai-ioc-bus-support/src/test/java/org/jboss/errai/ioc/support/bus/tests/BusIOCSupportTests.gwt.xml
+++ b/errai-ioc-bus-support/src/test/java/org/jboss/errai/ioc/support/bus/tests/BusIOCSupportTests.gwt.xml
@@ -9,4 +9,7 @@
   <inherits name="org.jboss.errai.bus.TestCommon"/>
 
   <inherits name="org.jboss.errai.ioc.support.bus.BusSupport" />
+
+  <!-- GWT 2.8.2 changed the value (by default) to 'REPORT_IF_NO_HANDLER' which is causing test failures. -->
+  <set-property name="gwt.uncaughtexceptionhandler.windowonerror" value="IGNORE"/>
 </module>

--- a/errai-ioc-bus-support/src/test/java/org/jboss/errai/ioc/support/tests/factory/IOCFactoryTests.gwt.xml
+++ b/errai-ioc-bus-support/src/test/java/org/jboss/errai/ioc/support/tests/factory/IOCFactoryTests.gwt.xml
@@ -9,4 +9,7 @@
   <inherits name="org.jboss.errai.bus.TestCommon"/>
 
   <inherits name="org.jboss.errai.ioc.support.bus.BusSupport" />
+
+  <!-- GWT 2.8.2 changed the value (by default) to 'REPORT_IF_NO_HANDLER' which is causing test failures. -->
+  <set-property name="gwt.uncaughtexceptionhandler.windowonerror" value="IGNORE"/>
 </module>

--- a/errai-security/errai-security-client/src/test/java/org/jboss/errai/security/SecurityInterceptorTest.gwt.xml
+++ b/errai-security/errai-security-client/src/test/java/org/jboss/errai/security/SecurityInterceptorTest.gwt.xml
@@ -10,4 +10,6 @@
   
   <source path="client"/>
 
+  <!-- GWT 2.8.2 changed the value (by default) to 'REPORT_IF_NO_HANDLER' which is causing test failures. -->
+  <set-property name="gwt.uncaughtexceptionhandler.windowonerror" value="IGNORE"/>
 </module>

--- a/errai-security/errai-security-client/src/test/java/org/jboss/errai/security/SecurityTest.gwt.xml
+++ b/errai-security/errai-security-client/src/test/java/org/jboss/errai/security/SecurityTest.gwt.xml
@@ -7,4 +7,6 @@
 
   <source path="client"/>
 
+  <!-- GWT 2.8.2 changed the value (by default) to 'REPORT_IF_NO_HANDLER' which is causing test failures. -->
+  <set-property name="gwt.uncaughtexceptionhandler.windowonerror" value="IGNORE"/>
 </module>

--- a/errai-ui/pom.xml
+++ b/errai-ui/pom.xml
@@ -230,7 +230,7 @@
                 </property>
               </systemProperties>
 
-              <!-- GWT 2.8.1 has an assertion that fails on tests and works in production -->
+              <!-- GWT 2.8.1+ has an assertion that fails on tests and works in production -->
               <enableAssertions>false</enableAssertions>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>              
-          <version>2.8.1</version>
+          <version>2.8.2</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
GWT 2.8.2 is the first release that should support bulding with Java 9
(it does not support Java 9 features; just the legacy classpath mode)