### PR TITLE
Ignore bindable interfaces

### DIFF
--- a/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/DataBindingUtil.java
+++ b/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/DataBindingUtil.java
@@ -514,7 +514,11 @@ public class DataBindingUtil {
   }
 
   private static boolean validateWildcard(MetaClass bindable) {
-    if (bindable.isFinal()) {
+    if (bindable.isInterface()) {
+      log.debug("@Bindable types cannot be an interface, ignoring: {}", bindable.getFullyQualifiedName());
+      return false;
+    }
+    else if (bindable.isFinal()) {
       log.debug("@Bindable types cannot be final, ignoring: {}", bindable.getFullyQualifiedName());
       return false;
     }


### PR DESCRIPTION
Sometimes interfaces are picked up in the bindable wildcard check. We can ignore them as we get an exception regarding no default constructor existing.