### PR TITLE
ERRAI-1099: Update current pages state without performing a full page navigation

### DIFF
--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
@@ -648,6 +648,21 @@ public class Navigation {
   }-*/;
 
   /**
+   * Update the state of your existing page without performing a full navigation.
+   * <br/>
+   * This will perform a pseudo navigation updating the history token with the new states.
+   */
+  public void updateState(Multimap<String, String> state) {
+    if(currentPage != null) {
+      currentPageToken = historyTokenFactory.createHistoryToken(currentPage.name(), state);
+      HistoryWrapper.newItem(currentPageToken.toString(), false);
+      currentPage.pageUpdate(currentComponent, currentPageToken);
+    } else {
+      logger.error("Cannot update the state before a page has loaded.");
+    }
+  }
+
+  /**
    * Are we in the navigation process right now.
    */
   public boolean isNavigating() {

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageUpdate.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageUpdate.java
@@ -48,9 +48,7 @@ import java.lang.annotation.*;
  * @see Page
  * @see PageState
  * @see Navigation
- * @see PageShowing
- * @author Daniel Sachse <mail@w0mb.at>
- * @author Jonathan Fuerth <jfuerth@redhat.com>
+ * @see PageShown
  * @author Ben Dol
  */
 @Target(ElementType.METHOD)

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageUpdate.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/PageUpdate.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.ui.nav.client.local;
+
+import com.google.common.collect.Multimap;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that the target method should be called when the {@link Page}
+ * state has been updated from {@link Navigation#updateState(Multimap)}.
+ * This will not be invoked when a full page navigation cycle is invoked.
+ * Instead {@link PageShown} is more appropriate for full navigation requests.
+ * <p>
+ * When the client-side application is bootstrapping (the page is loading in the
+ * browser), the Navigation system waits until all Errai modules are fully
+ * initialized before displaying the initial page. Hence, it is safe to make RPC
+ * requests and to fire portable CDI events from within a {@link PageUpdate}
+ * method.
+ * <p>
+ * The target method is permitted an optional parameter of type
+ * {@link HistoryToken}. If the parameter is present, the framework will pass in
+ * the history token that caused the page to show. This is useful in cases where
+ * not all history token key names are known at compile time, so
+ * {@code @PageState} fields can't be declared to accept their values.
+ * <p>
+ * The target method's return type must be {@code void}.
+ * <p>
+ * The target method can have any access type: public, protected, default, or
+ * private.
+ * <p>
+ * If the target method throws an exception when called, behaviour is undefined.
+ *
+ * @see Page
+ * @see PageState
+ * @see Navigation
+ * @see PageShowing
+ * @author Daniel Sachse <mail@w0mb.at>
+ * @author Jonathan Fuerth <jfuerth@redhat.com>
+ * @author Ben Dol
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface PageUpdate {
+
+}

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/spi/PageNode.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/spi/PageNode.java
@@ -19,11 +19,13 @@ package org.jboss.errai.ui.nav.client.local.spi;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 
+import com.google.common.collect.Multimap;
 import org.jboss.errai.common.client.util.CreationalCallback;
 import org.jboss.errai.ui.nav.client.local.HistoryToken;
 import org.jboss.errai.ui.nav.client.local.Page;
 import org.jboss.errai.ui.nav.client.local.TransitionTo;
 import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
+import org.jboss.errai.ui.nav.client.local.Navigation;
 
 import com.google.gwt.user.client.ui.IsWidget;
 
@@ -99,7 +101,7 @@ public interface PageNode<C> {
    *
    * @param widget
    *          the widget instance (which is currently in the navigation content panel) that was previously used in the
-   *          call to {@link #pageShowing(IsWidget, HistoryToken)}. Never null.
+   *          call to {@link #pageShowing(C, HistoryToken, NavigationControl)}. Never null.
    */
   public void pageHiding(C widget, NavigationControl control);
 
@@ -110,9 +112,22 @@ public interface PageNode<C> {
    *
    * @param widget
    *          the widget instance (which was in the navigation content panel) that was previously used in the call to
-   *          {@link #pageShowing(IsWidget, HistoryToken)}. Never null.
+   *          {@link #pageShowing(C, HistoryToken, NavigationControl)}. Never null.
    */
   public void pageHidden(C widget);
+
+  /**
+   * Called by the framework when this page node state was updated {@link Navigation#updateState(Multimap)}.
+   * <p>
+   * If this method throws an exception when called, framework behaviour is undefined.
+   *
+   * @param widget
+   *          the widget instance that was just returned from a call to {@link #produceContent(CreationalCallback)}.
+   *          Never null.
+   * @param state
+   *          the state of the page, parsed from the history token on the URL. Never null.
+   */
+  public void pageUpdate(C widget, HistoryToken state);
 
   /**
    * Used by the framework to destroy {@link Dependent} scoped beans after a page is no longer needed. For

--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/rebind/NavigationGraphGenerator.java
@@ -58,22 +58,7 @@ import org.jboss.errai.config.util.ClassScanner;
 import org.jboss.errai.enterprise.client.cdi.api.CDI;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.marshalling.rebind.util.MarshallingGenUtil;
-import org.jboss.errai.ui.nav.client.local.DefaultPage;
-import org.jboss.errai.ui.nav.client.local.HistoryToken;
-import org.jboss.errai.ui.nav.client.local.Page;
-import org.jboss.errai.ui.nav.client.local.PageHidden;
-import org.jboss.errai.ui.nav.client.local.PageHiding;
-import org.jboss.errai.ui.nav.client.local.PageRole;
-import org.jboss.errai.ui.nav.client.local.PageShowing;
-import org.jboss.errai.ui.nav.client.local.PageShown;
-import org.jboss.errai.ui.nav.client.local.PageState;
-import org.jboss.errai.ui.nav.client.local.TransitionAnchor;
-import org.jboss.errai.ui.nav.client.local.TransitionAnchorFactory;
-import org.jboss.errai.ui.nav.client.local.TransitionTo;
-import org.jboss.errai.ui.nav.client.local.TransitionToRole;
-import org.jboss.errai.ui.nav.client.local.URLPattern;
-import org.jboss.errai.ui.nav.client.local.URLPatternMatcher;
-import org.jboss.errai.ui.nav.client.local.UniquePageRole;
+import org.jboss.errai.ui.nav.client.local.*;
 import org.jboss.errai.ui.nav.client.local.api.NavigationControl;
 import org.jboss.errai.ui.nav.client.local.spi.NavigationGraph;
 import org.jboss.errai.ui.nav.client.local.spi.PageNode;
@@ -321,6 +306,7 @@ public class NavigationGraphGenerator extends AbstractAsyncGenerator {
 
     appendPageShowingMethod(pageImplBuilder, pageClass);
     appendPageShownMethod(pageImplBuilder, pageClass);
+    appendPageUpdateMethod(pageImplBuilder, pageClass);
 
     appendDestroyMethod(pageImplBuilder, pageClass);
 
@@ -527,6 +513,18 @@ public class NavigationGraphGenerator extends AbstractAsyncGenerator {
             .body();
 
     appendPageShowMethod(method, pageImplBuilder, pageClass, PageShown.class, false,
+        Parameter.of(HistoryToken.class, "state"));
+
+    method.finish();
+  }
+
+  private void appendPageUpdateMethod(AnonymousClassStructureBuilder pageImplBuilder, MetaClass pageClass) {
+    BlockBuilder<?> method = pageImplBuilder.publicMethod(void.class, createMethodNameFromAnnotation(PageUpdate.class),
+        Parameter.of(pageClass, "widget"),
+        Parameter.of(HistoryToken.class, "state"))
+        .body();
+
+    appendPageShowMethod(method, pageImplBuilder, pageClass, PageUpdate.class, false,
         Parameter.of(HistoryToken.class, "state"));
 
     method.finish();

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/PageLifecycleTest.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/PageLifecycleTest.java
@@ -172,6 +172,28 @@ public class PageLifecycleTest extends AbstractErraiCDITest {
     assertEquals("foo", page.getState());
   }
 
+  public void testPageUpdateMethodCalled() throws Exception {
+    PageWithLifecycleMethods page = Factory.maybeUnwrapProxy(beanManager.lookupBean(PageWithLifecycleMethods.class).getInstance());
+    page.afterUpdateCallCount = 0;
+
+    navigation.goTo(PageWithLifecycleMethods.class, ImmutableMultimap.of("state", "foo"));
+    navigation.updateState(ImmutableMultimap.of("state", "bar"));
+
+    assertEquals(1, page.afterUpdateCallCount);
+    assertEquals("bar", page.stateAfterUpdateWasCalled);
+  }
+
+  public void testPageUpdateMethodCalledForNonCompositeTemplated() throws Exception {
+    NonCompositePageWithLifecycleMethods page = Factory.maybeUnwrapProxy(beanManager.lookupBean(NonCompositePageWithLifecycleMethods.class).getInstance());
+    assertEquals(0, page.getUpdate());
+
+    navigation.goTo(NonCompositePageWithLifecycleMethods.class, ImmutableMultimap.of("state", "foo"));
+    navigation.updateState(ImmutableMultimap.of("state", "bar"));
+
+    assertEquals(1, page.getUpdate());
+    assertEquals("bar", page.getState());
+  }
+
   public void testPageHidingMethodCalled() throws Exception {
     PageWithLifecycleMethods page = Factory.maybeUnwrapProxy(beanManager.lookupBean(PageWithLifecycleMethods.class).getInstance());
 

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/NonCompositePageWithLifecycleMethods.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/NonCompositePageWithLifecycleMethods.java
@@ -18,12 +18,7 @@ package org.jboss.errai.ui.nav.client.local.testpages;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.jboss.errai.ui.nav.client.local.Page;
-import org.jboss.errai.ui.nav.client.local.PageHidden;
-import org.jboss.errai.ui.nav.client.local.PageHiding;
-import org.jboss.errai.ui.nav.client.local.PageShowing;
-import org.jboss.errai.ui.nav.client.local.PageShown;
-import org.jboss.errai.ui.nav.client.local.PageState;
+import org.jboss.errai.ui.nav.client.local.*;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 
 /**
@@ -34,7 +29,7 @@ import org.jboss.errai.ui.shared.api.annotations.Templated;
 @ApplicationScoped
 public class NonCompositePageWithLifecycleMethods {
 
-  private int showing = 0, shown = 0, hiding = 0, hidden = 0;
+  private int showing = 0, shown = 0, hiding = 0, hidden = 0, update = 0;
 
   @PageState
   private String state;
@@ -59,6 +54,11 @@ public class NonCompositePageWithLifecycleMethods {
     hidden++;
   }
 
+  @PageUpdate
+  private void update() {
+    update++;
+  }
+
   public String getState() {
     return state;
   }
@@ -79,4 +79,7 @@ public class NonCompositePageWithLifecycleMethods {
     return hidden;
   }
 
+  public int getUpdate() {
+    return update;
+  }
 }

--- a/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithLifecycleMethods.java
+++ b/errai-navigation/src/test/java/org/jboss/errai/ui/nav/client/local/testpages/PageWithLifecycleMethods.java
@@ -18,12 +18,7 @@ package org.jboss.errai.ui.nav.client.local.testpages;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.jboss.errai.ui.nav.client.local.Page;
-import org.jboss.errai.ui.nav.client.local.PageHidden;
-import org.jboss.errai.ui.nav.client.local.PageHiding;
-import org.jboss.errai.ui.nav.client.local.PageShowing;
-import org.jboss.errai.ui.nav.client.local.PageShown;
-import org.jboss.errai.ui.nav.client.local.PageState;
+import org.jboss.errai.ui.nav.client.local.*;
 
 import com.google.gwt.user.client.ui.VerticalPanel;
 
@@ -36,8 +31,10 @@ public class PageWithLifecycleMethods extends VerticalPanel {
   public int afterShowCallCount = 0;
   public int beforeHideCallCount = 0;
   public int afterHideCallCount = 0;
+  public int afterUpdateCallCount = 0;
 
   public String stateWhenBeforeShowWasCalled;
+  public String stateAfterUpdateWasCalled;
 
   @PageShowing
   private void beforeShow() {
@@ -59,5 +56,11 @@ public class PageWithLifecycleMethods extends VerticalPanel {
   @PageHidden
   private void afterHide() {
 	  afterHideCallCount++;
+  }
+
+  @PageUpdate
+  private void afterUpdate() {
+    afterUpdateCallCount++;
+    stateAfterUpdateWasCalled = state;
   }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ERRAI-1099

This is something that we find very useful when it comes to retaining our pages workflow in the URL. With this we just call `updateState` with a new set of state data (or a modified version) and we retain the pages initial state.

Let me know if there are any unseen limitations here or if there would be a better way to manage something like this, but as far as I have tested it seems to be working very well.

Note that this isn't actually invoking a navigation, it is simply updating the URL for the next navigation attempt. If this isn't done the states will always match the currentPageToken's states when, navigating backwards for example and therefore the navigation process is ended prematurely.

This introduces the `@PageUpdate` lifecycle hook that will be invoked when Navigation.updateState is called.

Tests provided.

Thanks!