### PR TITLE
Implement PayloadPreprocessor for server side payload processing.

### DIFF
--- a/errai-marshalling/src/main/java/org/jboss/errai/marshalling/server/protocol/ErraiProtocolServer.java
+++ b/errai-marshalling/src/main/java/org/jboss/errai/marshalling/server/protocol/ErraiProtocolServer.java
@@ -18,6 +18,8 @@ package org.jboss.errai.marshalling.server.protocol;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.jboss.errai.marshalling.client.protocols.ErraiProtocol;
@@ -25,12 +27,30 @@ import org.jboss.errai.marshalling.client.protocols.ErraiProtocol;
 /**
  * @author Mike Brock
  */
-public class ErraiProtocolServer extends ErraiProtocol{
+public class ErraiProtocolServer extends ErraiProtocol {
+
+  private static List<PayloadPreprocessor> preprocessors = new ArrayList<>();
+
   public static ByteArrayInputStream encodePayloadToByteArrayInputStream(final Map<String, Object> payload) {
     try {
+      // Process the payload before the encoding process.
+      preprocessors.forEach(preprocessor -> preprocessor.process(payload));
+
       return new ByteArrayInputStream(encodePayload(payload).getBytes("UTF-8"));
     } catch (UnsupportedEncodingException e) {
       throw new AssertionError("UTF-8 appears not to be supported by this JRE, but that's impossible");
     }
+  }
+
+  public static void addPreprocessor(PayloadPreprocessor preprocessor) {
+    preprocessors.add(preprocessor);
+  }
+
+  public static void removePreprocessor(PayloadPreprocessor preprocessor) {
+    preprocessors.remove(preprocessor);
+  }
+
+  public static void clearPreprocessors() {
+    preprocessors.clear();
   }
 }

--- a/errai-marshalling/src/main/java/org/jboss/errai/marshalling/server/protocol/PayloadPreprocessor.java
+++ b/errai-marshalling/src/main/java/org/jboss/errai/marshalling/server/protocol/PayloadPreprocessor.java
@@ -1,0 +1,8 @@
+package org.jboss.errai.marshalling.server.protocol;
+
+import java.util.Map;
+
+public interface PayloadPreprocessor {
+
+  void process(Map<String, Object> payload);
+}


### PR DESCRIPTION
This allows us to preprocess the payload before it is encoded.

The most predominant use case we have at the moment is this example:
```java
public class HibernatePayloadPreprocessor implements PayloadPreprocessor {

    @Override
    public void process(Map<String, Object> payload) {
        if(payload.containsKey("MethodReply")) {
            payload.put("MethodReply", HibernateUtil.cleanFromProxies(payload.get("MethodReply")));
        }
    }
}
```
Then we would just need to call:
```java
ErraiProtocolServer.addPreprocessor(new HibernatePayloadPreprocessor());
```

This allows us to preprocess the payload before being sent to the encoder. We are able to avoid: `org.hibernate.LazyInitializationException: could not initialize proxy - no Session` exceptions.

Thanks!