### PR TITLE
Fixed double slashes in Jaxrs path

### DIFF
--- a/errai-jaxrs/errai-jaxrs-client/src/main/java/org/jboss/errai/enterprise/client/jaxrs/api/RestClient.java
+++ b/errai-jaxrs/errai-jaxrs-client/src/main/java/org/jboss/errai/enterprise/client/jaxrs/api/RestClient.java
@@ -183,8 +183,6 @@ public class RestClient {
 
     Assert.notNull(remoteService);
     Assert.notNull(callback);
-    if (baseUrl != null && !baseUrl.endsWith("/"))
-      baseUrl += "/";
 
     T proxy = proxyProvider.getRemoteProxy(remoteService);
 
@@ -210,9 +208,6 @@ public class RestClient {
       return ""; 
     } 
     else {
-      if ($wnd.erraiJaxRsApplicationRoot.substr(-1) !== "/") {
-        return $wnd.erraiJaxRsApplicationRoot + "/";
-      }
       return $wnd.erraiJaxRsApplicationRoot;
     }
   }-*/;


### PR DESCRIPTION
```
RestClient.setApplicationRoot("/root"); 
//and
RestClient.setApplicationRoot("/root/");
```

Both creates a path like "/root//endpoint"