### PR TITLE
ERRAI-1104: Ability to intercept any remote call from the ClientMessageBus

### DIFF
--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/ErraiBus.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/ErraiBus.java
@@ -26,10 +26,7 @@ import org.jboss.errai.bus.client.api.SubscribeListener;
 import org.jboss.errai.bus.client.api.Subscription;
 import org.jboss.errai.bus.client.api.TransportErrorHandler;
 import org.jboss.errai.bus.client.api.UnsubscribeListener;
-import org.jboss.errai.bus.client.api.messaging.Message;
-import org.jboss.errai.bus.client.api.messaging.MessageBus;
-import org.jboss.errai.bus.client.api.messaging.MessageCallback;
-import org.jboss.errai.bus.client.api.messaging.RequestDispatcher;
+import org.jboss.errai.bus.client.api.messaging.*;
 import org.jboss.errai.common.client.api.extension.InitVotes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,6 +100,14 @@ public class ErraiBus implements EntryPoint {
 
         @Override
         public void addUnsubscribeListener(final UnsubscribeListener listener) {
+        }
+
+        @Override
+        public void addInterceptor(MessageInterceptor interceptor) {
+        }
+
+        @Override
+        public void removeInterceptor(MessageInterceptor interceptor) {
         }
 
         @Override

--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/api/ClientMessageBus.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/api/ClientMessageBus.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.bus.client.api.messaging.MessageBus;
 import org.jboss.errai.bus.client.api.messaging.MessageCallback;
+import org.jboss.errai.bus.client.api.messaging.MessageInterceptor;
 
 /**
  * An extended client-specific/in-browser interface of {@link org.jboss.errai.bus.client.api.messaging.MessageBus}, which defines client-specific functionality.
@@ -115,6 +116,16 @@ public interface ClientMessageBus extends MessageBus {
    *          given handler is {@code null} or it was not already registered.
    */
   public void removeTransportErrorHandler(TransportErrorHandler errorHandler);
+
+  /**
+   * Register a global message interceptor to intercept all message bus messages.
+   */
+  public void addInterceptor(MessageInterceptor interceptor);
+
+  /**
+   * Remove a global message interceptor.
+   */
+  public void removeInterceptor(MessageInterceptor interceptor);
 
   /**
    * Sets a property on the bus.

--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/api/messaging/MessageInterceptor.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/api/messaging/MessageInterceptor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.errai.bus.client.api.messaging;
+
+public interface MessageInterceptor {
+
+    /**
+     * Before the message is sent.
+     */
+    void beforeCall(Message message);
+
+    /**
+     * After the message was sent and returned to the client.
+     */
+    void afterCall(Message message);
+}


### PR DESCRIPTION
Allows us to do the following as an example:
```java
public class PingMessageInterceptor implements MessageInterceptor {

    private long begin;

    @Override
    public void beforeCall(Message message) {
        begin = new Date().getTime();
    }

    @Override
    public void afterCall(Message message) {
        // check the ping and perform tasks
    }
}
```

```java
ErraiBus.get().addInterceptor(interceptor);
```
Now we can make checks on any remote call rather than just specific calls.