### PR TITLE
Remove unneeded log.warning(...)

### DIFF
--- a/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
+++ b/errai-navigation/src/main/java/org/jboss/errai/ui/nav/client/local/Navigation.java
@@ -181,7 +181,6 @@ public class Navigation {
             navigate(new Request<>(toPage, token), false);
           }
         } catch (final Exception e) {
-          logger.warn("An error occurred while navigating.", e);
           if (token == null)
             navigationErrorHandler.handleInvalidURLError(e, event.getValue());
           else


### PR DESCRIPTION
This is a very simple patch that removes a single line of logging code.
```Navigation.setErrorHandler(....)``` allows the user to install custom error handler, which is supposed to handle navigation exception. Unfortunately, there is an extra line of logging code that emits a warning *before* the handler get a chance to process the exceptions. Further, ```DefaultNavigationErrorHandler``` already has plenty of logging already during the exception handling, so warning logs seems duplicate and clutters the browser JS console.

Please remove the single logging line with this pull request.