### PR TITLE
ERRAI-1110: Implement 'single only' event support.

### DIFF
--- a/errai-cdi/errai-cdi-shared/src/main/java/org/jboss/errai/enterprise/client/cdi/api/CDI.java
+++ b/errai-cdi/errai-cdi-shared/src/main/java/org/jboss/errai/enterprise/client/cdi/api/CDI.java
@@ -74,6 +74,7 @@ public class CDI {
 
   private static Map<String, List<AbstractCDIEventCallback<?>>> eventObservers = new HashMap<>();
   private static Set<String> localOnlyObserverTypes = new HashSet<>();
+  private static Set<String> singleOnlyObserverTypes = new HashSet<>();
   private static Map<String, Collection<String>> lookupTable = Collections.emptyMap();
   private static Map<String, List<MessageFireDeferral>> fireOnSubscribe = new LinkedHashMap<>();
 
@@ -177,22 +178,47 @@ public class CDI {
     }
   }
 
-  public static Subscription subscribeLocal(final String eventType, final AbstractCDIEventCallback<?> callback) {
-    return subscribeLocal(eventType, callback, true);
-  }
-
   public static Subscription subscribeJsType(final String eventType, final JsTypeEventObserver<?> callback) {
-    WindowEventObservers.createOrGet().add(eventType, callback);
-     return new Subscription() {
-       @Override
-       public void remove() {
-         // TODO can't unsubscribe per module atm.
-       }
-     };
+    return subscribeJsType(eventType, callback, false);
   }
 
-  private static Subscription subscribeLocal(final String eventType, final AbstractCDIEventCallback<?> callback,
-          final boolean isLocalOnly) {
+  public static Subscription subscribeJsType(final String eventType, final JsTypeEventObserver<?> callback,
+                                             boolean isSingleOnly) {
+    if (isSingleOnlyEventType(eventType) && hasOneOrMoreObservers(eventType)) {
+      logger.debug("Attempted to subscribeJsType '" +
+          eventType + "' which is 'single only' and already has an event observer.");
+      return null;
+    }
+
+    setSingleOnlyEventType(eventType, isSingleOnly);
+
+    WindowEventObservers.createOrGet().add(eventType, callback);
+    return new Subscription() {
+      @Override
+      public void remove() {
+        // TODO can't unsubscribe per module atm.
+      }
+    };
+  }
+
+  public static Subscription subscribeLocal(final String eventType, final AbstractCDIEventCallback<?> callback) {
+    return subscribeLocal(eventType, false, callback);
+  }
+
+  public static Subscription subscribeLocal(final String eventType, boolean isSingleOnly, final AbstractCDIEventCallback<?> callback) {
+    return subscribeLocal(eventType, isSingleOnly, callback, true);
+  }
+
+  private static Subscription subscribeLocal(final String eventType, boolean isSingleOnly, final AbstractCDIEventCallback<?> callback,
+                                             final boolean isLocalOnly) {
+
+    if (isSingleOnlyEventType(eventType) && hasOneOrMoreObservers(eventType)) {
+      logger.debug("Attempted to subscribeLocal '" +
+          eventType + "' which is 'single only' and already has an event observer.");
+      return null;
+    }
+
+    setSingleOnlyEventType(eventType, isSingleOnly);
 
     if (!eventObservers.containsKey(eventType)) {
       eventObservers.put(eventType, new ArrayList<AbstractCDIEventCallback<?>>());
@@ -212,9 +238,20 @@ public class CDI {
   }
 
   public static Subscription subscribe(final String eventType, final AbstractCDIEventCallback<?> callback) {
+    return subscribe(eventType, callback, false);
+  }
+
+  public static Subscription subscribe(final String eventType, final AbstractCDIEventCallback<?> callback,
+                                       boolean singleOnly) {
+
+    if (isSingleOnlyEventType(eventType) && hasOneOrMoreObservers(eventType)) {
+      logger.debug("Attempted to subscribe '" +
+          eventType + "' which is 'single only' and already has an event observer.");
+      return null;
+    }
 
     if (isRemoteCommunicationEnabled() && ErraiBus.get() instanceof ClientMessageBusImpl
-            && ((ClientMessageBusImpl) ErraiBus.get()).getState().equals(BusState.CONNECTED)) {
+        && ((ClientMessageBusImpl) ErraiBus.get()).getState().equals(BusState.CONNECTED)) {
       MessageBuilder.createMessage()
           .toSubject(CDI.SERVER_DISPATCHER_SUBJECT)
           .command(CDICommands.RemoteSubscribe)
@@ -223,7 +260,7 @@ public class CDI {
           .noErrorHandling().sendNowWith(ErraiBus.get());
     }
 
-    return subscribeLocal(eventType, callback, false);
+    return subscribeLocal(eventType, singleOnly, callback, false);
   }
 
   private static void unsubscribe(final String eventType, final AbstractCDIEventCallback<?> callback) {
@@ -254,6 +291,27 @@ public class CDI {
         }
       }
     }
+  }
+
+  public static boolean isSingleOnlyEventType(final String eventType) {
+    return singleOnlyObserverTypes.contains(eventType);
+  }
+
+  /**
+   * Mark an event type as 'single only' in order to restrict multiple event handlers from being registered.
+   * @param eventType the event type name used when registering an event.
+   */
+  public static void setSingleOnlyEventType(String eventType, boolean isSingleOnly) {
+    if (isSingleOnly) {
+      singleOnlyObserverTypes.add(eventType);
+    } else {
+      singleOnlyObserverTypes.remove(eventType);
+    }
+  }
+
+  public static boolean hasOneOrMoreObservers(final String eventType) {
+    List<AbstractCDIEventCallback<?>> callbacks = eventObservers.get(eventType);
+    return callbacks != null && !callbacks.isEmpty();
   }
 
   /**


### PR DESCRIPTION
This will allow us to setSingleOnlyEventType marking an event type with a single handler in some edge cases.