### PR TITLE
Fix an issue with SecurityContextHoldingSingleton loading

### DIFF
--- a/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/nav/SecurityContextHoldingSingleton.java
+++ b/errai-security/errai-security-client/src/main/java/org/jboss/errai/security/client/local/nav/SecurityContextHoldingSingleton.java
@@ -18,11 +18,11 @@ package org.jboss.errai.security.client.local.nav;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.security.client.local.api.SecurityContext;
 
-@EntryPoint
+@Singleton
 public class SecurityContextHoldingSingleton {
   
   private static SecurityContextHoldingSingleton instance;


### PR DESCRIPTION
There are cases where this dependency isn't loaded as a singleton.