### PR TITLE
Log throwable if it's not null

### DIFF
--- a/errai-bus/src/main/java/org/jboss/errai/bus/client/util/ErrorHelper.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/client/util/ErrorHelper.java
@@ -226,7 +226,7 @@ public class ErrorHelper {
             "\ndisconnect: " + disconnect;
 
     if (!(e instanceof MessageDeliveryFailure && ((MessageDeliveryFailure) e).isRpcEndpointException())) {
-      if (e != null) {
+      if (e == null) {
         logger.error(logMessage);
       }
       else {


### PR DESCRIPTION
Due to the inverted condition, the throwable was actually ignored if it
wasn't null, which is the opposite of what was intended.