### PR TITLE
ERRAI-1115: Fix content type issues with the StandardAsyncServlet

### DIFF
--- a/errai-bus/src/main/java/org/jboss/errai/bus/server/servlet/StandardAsyncServlet.java
+++ b/errai-bus/src/main/java/org/jboss/errai/bus/server/servlet/StandardAsyncServlet.java
@@ -72,6 +72,7 @@ public class StandardAsyncServlet extends AbstractErraiServlet {
 
     
     final AsyncContext asyncContext = request.startAsync();
+    asyncContext.getResponse().setContentType("application/json");
     asyncContext.setTimeout(60000);
     queue.setTimeout(65000);
     
@@ -161,6 +162,7 @@ public class StandardAsyncServlet extends AbstractErraiServlet {
           doGet(request, response);
         }
         else {
+          response.setContentType("application/json");
           queue.poll(new OutputStreamWriteAdapter(response.getOutputStream()));
         }
       }


### PR DESCRIPTION
Since the validateContentType method in HttpPollingHandler expects `application/json` we have to ensure our polling is sent as such.

I have a feeling this is actually an issue with the way we are checking inside the HttpPollingHandler. Since I'm not 100% sure how it is meant to work, I will just fix the servlet.