### PR TITLE
[4.3.x] Fix for ECJ - GWT conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ gwt-unitCache/
 class_list.txt
 *.jpage
 .factorypath
+dependency-reduced-pom.xml

--- a/errai-codegen/pom.xml
+++ b/errai-codegen/pom.xml
@@ -42,14 +42,124 @@
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-dev</artifactId>
-      <!-- This should not be packaged with the Errai Distro. There are no
-runtime dependencies on it and it breaks deployment on JBoss AS and Tomcat -->
-      <scope>provided</scope>
+      <!-- We need a compile scope for making the shade work (see below), but we don't want to inherit the
+      transitive dependencies of the gwt-dev.jar, so for safety we exclude them manually -->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-commons</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>colt</groupId>
+          <artifactId>colt</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.ibm.icu</groupId>
+          <artifactId>icu4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tapestry</groupId>
+          <artifactId>tapestry</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.sourceforge.htmlunit</groupId>
+          <artifactId>htmlunit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-webapp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlets</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>apache-jsp</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <minimizeJar>true</minimizeJar>
+              <createSourcesJar>true</createSourcesJar>
+              <artifactSet>
+                <includes>
+                  <include>com.google.gwt:gwt-dev</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>com.google.gwt:gwt-dev</artifact>
+                  <excludes>
+                      <exclude>com/google/gwt/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>org.eclipse.jdt</pattern>
+                  <shadedPattern>org.jboss.errai.codegen.shade.org.eclipse.jdt</shadedPattern>
+                  <excludes>
+                    <exclude>org.eclipse.jdt.core.prefs</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>org.osgi</pattern>
+                  <shadedPattern>org.jboss.errai.codegen.shade.org.osgi</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration combine.self="override">


### PR DESCRIPTION
    - This commit keeps errai-codgen module aligned with the ecj version used by gwt-dev by doing a shade of the ecj classes contained in the gwt-dev.jar.
      I this way the rest of the WB can use a different ecj version, etc, tipically configured in the droolsjbpm-build-boostrap file."

(cherry picked from commit 207bb3059160314b7b63204da67516405ecba1ea)