### PR TITLE
AF-1791: Update Elemental2 version to 1.0.0-RC1

### DIFF
--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -65,7 +65,7 @@
     <!-- The version of xercesImpl in the ip-bom is not published on Maven Central.
          Removing this override breaks Errai apps that don't have the JBoss nexus repository configured. -->
     <version.xerces.xercesImpl>2.11.0</version.xerces.xercesImpl>
-    <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
+    <version.com.google.elemental2>1.0.0-RC1</version.com.google.elemental2>
     <version.com.fasterxml.jackson>2.9.5</version.com.fasterxml.jackson>
     <version.org.jboss.websocket.spec>1.0.0.Final</version.org.jboss.websocket.spec>
     <version.org.mockito>2.12.0</version.org.mockito>


### PR DESCRIPTION
Related to:

https://github.com/kiegroup/appformer/pull/606
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/913
https://github.com/kiegroup/kie-wb-common/pull/2402
