### PR TITLE
Fix Hibernate proxy objects marshalling

### DIFF
--- a/errai-marshalling/src/main/java/org/jboss/errai/marshalling/client/util/MarshallUtil.java
+++ b/errai-marshalling/src/main/java/org/jboss/errai/marshalling/client/util/MarshallUtil.java
@@ -127,7 +127,9 @@ public class MarshallUtil {
       m = new FallbackExceptionMarshaller();
     }
     // Attempt to marshal weld/hibernate javassist created objects.
-    if (m == null && (obj.getClass().getName().contains("_$$_javassist_") || obj.getClass().getName().contains("_$$_jvst"))) {
+    if (m == null && (obj.getClass().getName().contains("$HibernateProxy") || obj.getClass().getName()
+            .contains("_$$_javassist_") || obj.getClass().getName().contains("_$$_jvst"))) {
+
       className = obj.getClass().getSuperclass().getName();
       m = session.getMarshallerInstance(className);
     }


### PR DESCRIPTION
This PR fixes the failing test on `RpcHibernateTest` and enables new Hibernate proxies to be marshalled/unmarshalled like the old ones were.