### PR TITLE
AF-1799: Upgrade JDK 11 + GWT 2.9

### DIFF
--- a/errai-jpa/errai-jpa-datasync/pom.xml
+++ b/errai-jpa/errai-jpa-datasync/pom.xml
@@ -62,6 +62,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.spec.javax.annotation</groupId>
+      <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>test</scope>

--- a/errai-reflections/reflections/src/test/java/org/jboss/errai/reflections/VfsTest.java
+++ b/errai-reflections/reflections/src/test/java/org/jboss/errai/reflections/VfsTest.java
@@ -78,51 +78,6 @@ public class VfsTest {
         Assert.assertFalse(files.iterator().hasNext());
     }
 
-//    @Test
-    public void vfsFromHttpUrl() throws MalformedURLException {
-        Vfs.addDefaultURLTypes(new Vfs.UrlType() {
-            public boolean matches(URL url)         {return url.getProtocol().equals("http");}
-            public Vfs.Dir createDir(final URL url) {return new HttpDir(url);}
-        });
-
-        testVfsDir(new URL("http://mirrors.ibiblio.org/pub/mirrors/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.jar"));
-    }
-
-    //this is just for the test...
-    static class HttpDir implements Vfs.Dir {
-        private final File file;
-        private final ZipDir zipDir;
-        private final String path;
-
-        HttpDir(URL url) {
-            this.path = url.toExternalForm();
-            try {file = downloadTempLocally(url);}
-            catch (IOException e) {throw new RuntimeException(e);}
-            zipDir = new ZipDir(file.getAbsolutePath());
-        }
-
-        public String getPath() {return path;}
-        public Iterable<Vfs.File> getFiles() {return zipDir.getFiles();}
-        public void close() {file.delete();}
-
-        private static java.io.File downloadTempLocally(URL url) throws IOException {
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            if (connection.getResponseCode() == 200) {
-                java.io.File temp = java.io.File.createTempFile("urlToVfs", "tmp");
-                FileOutputStream out = new FileOutputStream(temp);
-                DataInputStream in = new DataInputStream(connection.getInputStream());
-
-                int len; byte ch[] = new byte[1024];
-                while ((len = in.read(ch)) != -1) {out.write(ch, 0, len);}
-
-                connection.disconnect();
-                return temp;
-            }
-
-            return null;
-        }
-    }
-
     @Test
     public void vfsFromJarWithInnerJars() {
         //todo?

--- a/errai-validation/pom.xml
+++ b/errai-validation/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
       <classifier>sources</classifier>


### PR DESCRIPTION
This PR changes the way Errai finds `@Constraint`-annotated classes. Before, it was scanning the classpath, but on JDK11, the default classloader changed, making it not possible to do that anymore. 

This fix changes it to only scan for pre-configured constraints. Custom-defined constraints are still picked-up by scanning the GWT Generators classpath, so nothing changes on the upstream projects.

**Upgrade JDK 11 + GWT 2.9**

Feel free to comment and/or raise any concerns.

This PR continues the work done in 
- https://github.com/kiegroup/appformer/pull/1030
- https://github.com/kiegroup/appformer/pull/1039

Thanks guys for that!

**JIRA**:

[AF-1799](https://issues.redhat.com/browse/AF-1799)

**Parent Pull Request**:
- https://github.com/kiegroup/lienzo-core/pull/134

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
