### PR TITLE
fix: add @ApplicationScoped to LoggerProvider to restore CDI discovery under Weld 5

### DIFF
--- a/errai-cdi/errai-cdi-server/src/main/java/org/jboss/errai/cdi/server/providers/builtin/LoggerProvider.java
+++ b/errai-cdi/errai-cdi-server/src/main/java/org/jboss/errai/cdi/server/providers/builtin/LoggerProvider.java
@@ -16,6 +16,7 @@
 
 package org.jboss.errai.cdi.server.providers.builtin;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 
@@ -23,9 +24,8 @@ import org.jboss.errai.common.client.api.annotations.NamedLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ApplicationScoped
 public class LoggerProvider {
-  
-  
 
   @Produces
   public Logger produceLogger(final InjectionPoint injectionPoint) {


### PR DESCRIPTION
`LibraryAssetUpdateNotifier` and `IndexStatusOracle` (from `kie-wb-common-library-backend`) use
`@Inject Logger` — a pattern that depends on `LoggerProvider`'s `@Produces` method being visible
to CDI. This worked on WildFly 23 (Weld 3) but breaks on WildFly 35 (Weld 5) due to a spec
change in CDI 4.0.

### Root cause

`LoggerProvider` has no bean-defining annotation (`@ApplicationScoped`, `@Dependent`, etc.) and
`errai-cdi-server` ships an **empty (0-byte) `META-INF/beans.xml`**.

Under CDI 2.0 / Weld 3, an empty `beans.xml` implied `bean-discovery-mode="all"`, which caused
every class in the archive — including unannotated ones like `LoggerProvider` — to be discovered
as a CDI bean. CDI 4.0 / Weld 5 changed this: an empty `beans.xml` now implies
`bean-discovery-mode="annotated"`, so only classes carrying a bean-defining annotation are
discovered. `LoggerProvider` is silently skipped and its `@Produces` method is never registered,
leaving all `Logger` injection points unsatisfied.

| `beans.xml` content    | Weld 3 (CDI 2.0)  | Weld 5 (CDI 4.0)     |
|------------------------|-------------------|----------------------|
| Absent                 | `annotated`       | `annotated`          |
| Empty (0 bytes)        | **`all`**         | **`annotated`** ← changed |
| `bean-discovery-mode="all"` | `all`        | `all`                |
| `bean-discovery-mode="annotated"` | `annotated` | `annotated`    |

### Fix

Add `@ApplicationScoped` to `LoggerProvider`. This makes it a proper CDI-managed bean regardless
of discovery mode, and is the correct scope for a stateless producer: a single instance is
created and its `produceLogger` method is called for each `@Inject Logger` injection point,
receiving a fresh `InjectionPoint` per call so each injecting class gets its own named logger.